### PR TITLE
fix: require full authentication before showing logged-in state

### DIFF
--- a/app/(ui)/otp/[method]/components/action.ts
+++ b/app/(ui)/otp/[method]/components/action.ts
@@ -139,14 +139,16 @@ export async function handleOTPFormSubmit(
     await new Promise((resolve) => setTimeout(resolve, 2000));
 
     // Use unified approach that handles both OIDC/SAML and regular flows
+    // Always include sessionId to ensure we load the exact session that was just updated
     const callbackResponse = await completeFlowOrGetUrl(
-      submitParams.requestId && response.sessionId
+      submitParams.requestId
         ? {
             sessionId: response.sessionId,
             requestId: submitParams.requestId,
             organization: response.factors.user.organizationId,
           }
         : {
+            sessionId: response.sessionId,
             loginName: response.factors.user.loginName,
             organization: response.factors.user.organizationId,
           },

--- a/components/serverComponents/globals/Logout.tsx
+++ b/components/serverComponents/globals/Logout.tsx
@@ -3,15 +3,24 @@ import { getServiceUrlFromHeaders } from "@lib/service-url";
 import { serverTranslation } from "@i18n/server";
 import { loadSessionsFromCookies } from "@lib/server/session";
 import { LogoutButton } from "@clientComponents/globals/LogoutButton";
+import { isSessionValid } from "@lib/session";
 
 export const Logout = async ({ className }: { className?: string }) => {
   const _headers = await headers();
   const { serviceUrl } = getServiceUrlFromHeaders(_headers);
   const { t } = await serverTranslation("header");
-  const sessions = await loadSessionsFromCookies({ serviceUrl }).then((list) =>
-    list.filter((session) => session?.factors?.user?.loginName)
-  );
-  if (sessions.length < 1) {
+  const allSessions = await loadSessionsFromCookies({ serviceUrl });
+
+  // Filter to only fully authenticated sessions (isSessionValid is async)
+  const validSessions = await Promise.all(
+    allSessions.map(async (session) => {
+      if (!session?.factors?.user?.loginName) return null;
+      const valid = await isSessionValid({ serviceUrl, session });
+      return valid ? session : null;
+    })
+  ).then((results) => results.filter(Boolean));
+
+  if (validSessions.length < 1) {
     return null;
   }
 

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -5,12 +5,12 @@ type FinishFlowCommand =
       sessionId: string;
       requestId: string;
     }
-  | { loginName: string };
+  | { loginName: string; sessionId?: string };
 
 function goToSignedInPage(
   props:
     | { sessionId: string; organization?: string; requestId?: string }
-    | { organization?: string; loginName: string; requestId?: string }
+    | { organization?: string; loginName: string; sessionId?: string; requestId?: string }
 ) {
   const params = new URLSearchParams({});
 

--- a/lib/server/session.ts
+++ b/lib/server/session.ts
@@ -169,8 +169,10 @@ export async function continueWithSession({ requestId, ...session }: ContinueWit
       loginSettings?.defaultRedirectUri
     );
   } else if (session.factors?.user) {
+    // Always include sessionId to ensure we load the exact session that was just updated
     return completeFlowOrGetUrl(
       {
+        sessionId: session.id,
         loginName: session.factors.user.loginName,
         organization: session.factors.user.organizationId,
       },

--- a/lib/server/u2f.ts
+++ b/lib/server/u2f.ts
@@ -1,17 +1,16 @@
 "use server";
 
 import { getSession, getLoginSettings, registerU2F, verifyU2FRegistration } from "@lib/zitadel";
-import { create } from "@zitadel/client";
+import { create, Duration } from "@zitadel/client";
 import { VerifyU2FRegistrationRequestSchema } from "@zitadel/proto/zitadel/user/v2/user_service_pb";
 import { Checks } from "@zitadel/proto/zitadel/session/v2/session_service_pb";
-import { Duration } from "@zitadel/proto/google/protobuf/duration_pb";
 import { headers } from "next/headers";
 import { userAgent } from "next/server";
 import { getSessionCookieById, getSessionCookieByLoginName } from "../cookies";
 import { getServiceUrlFromHeaders } from "../../lib/service-url";
 import { getOriginalHost } from "./host";
 import { setSessionAndUpdateCookie } from "./cookie";
-import { updateSession, continueWithSession, ContinueWithSessionCommand } from "./session";
+import { continueWithSession } from "./session";
 import { U2F_ERRORS } from "./u2f-errors";
 
 type RegisterU2FCommand = {
@@ -175,7 +174,6 @@ export async function verifyU2FLogin({
   organization,
   checks,
   requestId,
-  checks,
   redirect,
 }: VerifyU2FLoginCommand) {
   const _headers = await headers();
@@ -215,5 +213,5 @@ export async function verifyU2FLogin({
     return { error: U2F_ERRORS.SESSION_VERIFICATION_FAILED };
   }
 
-  return continueWithSession({ ...updatedSession, requestId });
+  return continueWithSession({ ...updatedSession, requestId, redirect });
 }


### PR DESCRIPTION
# Summary | Résumé

- Add isSessionValid check to /signedin page to verify password + MFA
- Add isSessionValid check to Logout component to only show when fully authenticated
- Fix U2F login to actually verify the webAuthN credential (was being ignored)
- Fix continueWithSession to include sessionId in redirect URL
- Fix completeFlowOrGetUrl to always include sessionId after MFA completion
- Update FinishFlowCommand type to support sessionId with loginName

Fixes regression where 'Sign out' would appear after entering only username, and users could access /signedin without completing password or MFA.

