### PR TITLE
Refactor username lib and remove query params from password screen

### DIFF
--- a/app/(ui)/start/components/UserNameForm.tsx
+++ b/app/(ui)/start/components/UserNameForm.tsx
@@ -3,12 +3,13 @@
 import { useActionState, useEffect } from "react";
 import { Alert, Label, TextInput, ErrorStatus } from "@clientComponents/forms";
 import { useTranslation } from "@i18n/client";
-import { sendLoginname } from "@lib/server/username";
+
 import { useRouter } from "next/navigation";
 import { SubmitButtonAction } from "@clientComponents/globals/Buttons/SubmitButton";
 import { validateUsername } from "@lib/validationSchemas";
 import { ErrorMessage } from "@clientComponents/forms/ErrorMessage";
 import { ErrorSummary } from "@clientComponents/forms/ErrorSummary";
+import { sendLoginname } from "@lib/server/username";
 
 type Props = {
   loginName: string | undefined;

--- a/lib/server/username.ts
+++ b/lib/server/username.ts
@@ -2,28 +2,19 @@
 
 import { create } from "@zitadel/client";
 import { ChecksSchema } from "@zitadel/proto/zitadel/session/v2/session_service_pb";
-import { AuthenticationMethodType } from "@zitadel/proto/zitadel/user/v2/user_service_pb";
 import { serverTranslation } from "@i18n/server";
-import { headers } from "next/headers";
-import { idpTypeToIdentityProviderType, idpTypeToSlug } from "@lib/idp";
-
-import { PasskeysType } from "@zitadel/proto/zitadel/settings/v2/login_settings_pb";
-import { UserState } from "@zitadel/proto/zitadel/user/v2/user_pb";
 import { getServiceUrlFromHeaders } from "@lib/service-url";
 import {
-  getActiveIdentityProviders,
-  getIDPByID,
   getLoginSettings,
-  getOrgsByDomain,
   listAuthenticationMethodTypes,
-  listIDPLinks,
   searchUsers,
   SearchUsersCommand,
-  startIdentityProviderFlow,
 } from "@lib/zitadel";
-import { createSessionAndUpdateCookie } from "@lib/server/cookie";
-import { getOriginalHost } from "@lib/server/host";
-import { IDPLink } from "@zitadel/proto/zitadel/user/v2/idp_pb";
+import { headers } from "next/headers";
+import { createSessionAndUpdateCookie } from "./cookie";
+import { UserState } from "@zitadel/proto/zitadel/user/v2/user_pb";
+import { AuthenticationMethodType } from "@zitadel/proto/zitadel/user/v2/user_service_pb";
+import { logMessage } from "@lib/logger";
 
 export type SendLoginnameCommand = {
   loginName: string;
@@ -31,8 +22,6 @@ export type SendLoginnameCommand = {
   organization?: string;
   suffix?: string;
 };
-
-const ORG_SUFFIX_REGEX = /(?<=@)(.+)/;
 
 export async function sendLoginname(command: SendLoginnameCommand) {
   const _headers = await headers();
@@ -59,19 +48,21 @@ export async function sendLoginname(command: SendLoginnameCommand) {
 
   const searchResult = await searchUsers(searchUsersRequest);
 
+  // @TODO: verify these checks
+
   // Safety check: ensure searchResult is defined
   if (!searchResult) {
-    console.error("searchUsers returned undefined or null");
+    logMessage.error("searchUsers returned undefined or null");
     return { error: t("errors.couldNotSearchUsers") };
   }
 
   if ("error" in searchResult && searchResult.error) {
-    console.log("searchUsers returned error, returning early:", searchResult.error);
+    logMessage.error("searchUsers returned error, returning early: " + searchResult.error);
     return searchResult;
   }
 
   if (!("result" in searchResult)) {
-    console.log("searchUsers has no result field");
+    logMessage.error("searchUsers has no result field");
     return { error: t("errors.couldNotSearchUsers") };
   }
 
@@ -80,433 +71,52 @@ export async function sendLoginname(command: SendLoginnameCommand) {
   // Additional safety check: treat undefined result as empty array
   const users = potentialUsers ?? [];
 
-  if (users.length === 0) {
-    console.log("No users found, will proceed with org discovery");
+  // Note: searchUsers already returns an error if multiple users are found,
+  // so we only need to handle 0 or 1 user here
+  if (users.length === 0 || !users[0].userId) {
+    return { redirect: "/register" };
   }
 
-  const redirectUserToIDP = async (userId?: string, organization?: string) => {
-    // If userId is provided, check for user-specific IDP links first
-    let identityProviders: IDPLink[] = [];
-    if (userId) {
-      identityProviders = await listIDPLinks({
-        serviceUrl,
-        userId,
-      }).then((resp) => {
-        return resp.result;
-      });
+  const user = users[0];
+  const userId = users[0].userId;
+
+  const checks = create(ChecksSchema, {
+    user: { search: { case: "userId", value: userId } },
+  });
+
+  const sessionOrError = await createSessionAndUpdateCookie({
+    checks,
+    requestId: command.requestId,
+  }).catch((error) => {
+    if (error?.rawMessage === "Errors.User.NotActive (SESSION-Gj4ko)") {
+      return { error: t("errors.userNotActive") };
     }
+    throw error;
+  });
 
-    // If no IDP links exist for the user (or no userId provided), try to get active IDPs from the organization
-    if (identityProviders.length === 0) {
-      const activeIdps = await getActiveIdentityProviders({
-        serviceUrl,
-        orgId: organization,
-      }).then((resp) => {
-        return resp.identityProviders;
-      });
-
-      // If exactly one active IDP exists in the organization, redirect to it
-      if (activeIdps.length === 1) {
-        const _headers = await headers();
-        const { serviceUrl } = getServiceUrlFromHeaders(_headers);
-        const host = await getOriginalHost();
-
-        const identityProviderType = activeIdps[0].type;
-        const provider = idpTypeToSlug(identityProviderType);
-
-        const params = new URLSearchParams();
-
-        if (userId) {
-          params.set("userId", userId);
-        }
-
-        if (command.requestId) {
-          params.set("requestId", command.requestId);
-        }
-
-        if (organization) {
-          params.set("organization", organization);
-        }
-
-        const basePath = process.env.NEXT_PUBLIC_BASE_PATH ?? "";
-
-        const url = await startIdentityProviderFlow({
-          serviceUrl,
-          idpId: activeIdps[0].id,
-          urls: {
-            successUrl:
-              `${host.includes("localhost") ? "http://" : "https://"}${host}${basePath}/idp/${provider}/process?` +
-              new URLSearchParams(params),
-            failureUrl:
-              `${host.includes("localhost") ? "http://" : "https://"}${host}${basePath}/idp/${provider}/failure?` +
-              new URLSearchParams(params),
-          },
-        });
-
-        if (!url) {
-          return { error: t("errors.couldNotStartIDPFlow") };
-        }
-
-        return { redirect: url };
-      }
-    }
-
-    if (identityProviders.length === 1) {
-      const _headers = await headers();
-      const { serviceUrl } = getServiceUrlFromHeaders(_headers);
-      const host = await getOriginalHost();
-
-      const identityProviderId = identityProviders[0].idpId;
-
-      const idp = await getIDPByID({
-        serviceUrl,
-        id: identityProviderId,
-      });
-
-      const idpType = idp?.type;
-
-      if (!idp || !idpType) {
-        throw new Error(t("errors.couldNotFindIdentityProvider"));
-      }
-
-      const identityProviderType = idpTypeToIdentityProviderType(idpType);
-      const provider = idpTypeToSlug(identityProviderType);
-
-      const params = new URLSearchParams();
-
-      if (userId) {
-        params.set("userId", userId);
-      }
-
-      if (command.requestId) {
-        params.set("requestId", command.requestId);
-      }
-
-      if (organization) {
-        params.set("organization", organization);
-      }
-
-      const basePath = process.env.NEXT_PUBLIC_BASE_PATH ?? "";
-
-      const url = await startIdentityProviderFlow({
-        serviceUrl,
-        idpId: idp.id,
-        urls: {
-          successUrl:
-            `${host.includes("localhost") ? "http://" : "https://"}${host}${basePath}/idp/${provider}/process?` +
-            new URLSearchParams(params),
-          failureUrl:
-            `${host.includes("localhost") ? "http://" : "https://"}${host}${basePath}/idp/${provider}/failure?` +
-            new URLSearchParams(params),
-        },
-      });
-
-      if (!url) {
-        return { error: t("errors.couldNotStartIDPFlow") };
-      }
-
-      return { redirect: url };
-    }
-  };
-
-  if (users.length > 1) {
-    console.log("multiple users found, returning error");
-    return { error: t("errors.moreThanOneUserFound") };
-  } else if (users.length == 1 && users[0].userId) {
-    const user = users[0];
-    const userId = users[0].userId;
-
-    const userLoginSettings = await getLoginSettings({
-      serviceUrl,
-      organization: user.details?.resourceOwner,
-    });
-
-    // compare with the concatenated suffix when set
-    const concatLoginname = command.suffix
-      ? `${command.loginName}@${command.suffix}`
-      : command.loginName;
-
-    const humanUser = users[0].type.case === "human" ? users[0].type.value : undefined;
-
-    // recheck login settings after user discovery, as the search might have been done without org scope
-    if (userLoginSettings?.disableLoginWithEmail && userLoginSettings?.disableLoginWithPhone) {
-      if (user.preferredLoginName !== concatLoginname) {
-        return { error: t("errors.userNotFound") };
-      }
-    } else if (userLoginSettings?.disableLoginWithEmail) {
-      if (
-        user.preferredLoginName !== concatLoginname ||
-        humanUser?.phone?.phone !== command.loginName
-      ) {
-        return { error: t("errors.userNotFound") };
-      }
-    } else if (userLoginSettings?.disableLoginWithPhone) {
-      if (
-        user.preferredLoginName !== concatLoginname ||
-        humanUser?.email?.email !== command.loginName
-      ) {
-        return { error: t("errors.userNotFound") };
-      }
-    }
-
-    const checks = create(ChecksSchema, {
-      user: { search: { case: "userId", value: userId } },
-    });
-
-    const sessionOrError = await createSessionAndUpdateCookie({
-      checks,
-      requestId: command.requestId,
-    }).catch((error) => {
-      if (error?.rawMessage === "Errors.User.NotActive (SESSION-Gj4ko)") {
-        return { error: t("errors.userNotActive") };
-      }
-      throw error;
-    });
-
-    if ("error" in sessionOrError) {
-      return sessionOrError;
-    }
-
-    const session = sessionOrError;
-
-    if (!session.factors?.user?.id) {
-      return { error: t("errors.couldNotCreateSession") };
-    }
-
-    // TODO: check if handling of userstate INITIAL is needed
-    if (user.state === UserState.INITIAL) {
-      return { error: t("errors.initialUserNotSupported") };
-    }
-
-    // Resolve organization from command or session
-    const organization = command.organization ?? session.factors?.user?.organizationId;
-
-    const methods = await listAuthenticationMethodTypes({
-      serviceUrl,
-      userId: session.factors?.user?.id,
-    });
-
-    // always resend invite if user has no auth method set
-    if (!methods.authMethodTypes || !methods.authMethodTypes.length) {
-      const params = new URLSearchParams({
-        loginName: session.factors?.user?.loginName as string,
-        send: "true", // set this to true to request a new code immediately
-        invite: humanUser?.email?.isVerified ? "false" : "true", // sendInviteEmailCode results in an error if user is already initialized
-      });
-
-      if (command.requestId) {
-        params.append("requestId", command.requestId);
-      }
-
-      if (organization) {
-        params.append("organization", organization);
-      }
-
-      return { redirect: `/verify?` + params };
-    }
-
-    if (methods.authMethodTypes.length == 1) {
-      const method = methods.authMethodTypes[0];
-      switch (method) {
-        case AuthenticationMethodType.PASSWORD: // user has only password as auth method
-          if (!userLoginSettings?.allowUsernamePassword) {
-            // Check if user has IDPs available as alternative, that could eventually be used to register/link.
-            const idpResp = await redirectUserToIDP(userId, organization);
-            if (idpResp?.redirect) {
-              return idpResp;
-            }
-
-            return {
-              error: t("errors.usernamePasswordNotAllowed"),
-            };
-          }
-
-          const paramsPassword = new URLSearchParams({
-            loginName: session.factors?.user?.loginName,
-          });
-
-          // TODO: does this have to be checked in loginSettings.allowDomainDiscovery
-
-          if (organization) {
-            paramsPassword.append("organization", organization);
-          }
-
-          if (command.requestId) {
-            paramsPassword.append("requestId", command.requestId);
-          }
-
-          return {
-            redirect: "/password?" + paramsPassword,
-          };
-
-        case AuthenticationMethodType.PASSKEY: // AuthenticationMethodType.AUTHENTICATION_METHOD_TYPE_PASSKEY
-          if (userLoginSettings?.passkeysType === PasskeysType.NOT_ALLOWED) {
-            return {
-              error: t("errors.passkeysNotAllowed"),
-            };
-          }
-
-          const paramsPasskey = new URLSearchParams({
-            loginName: session.factors?.user?.loginName,
-          });
-          if (command.requestId) {
-            paramsPasskey.append("requestId", command.requestId);
-          }
-
-          if (organization) {
-            paramsPasskey.append("organization", organization);
-          }
-
-          return { redirect: "/passkey?" + paramsPasskey };
-
-        case AuthenticationMethodType.IDP:
-          const resp = await redirectUserToIDP(userId, organization);
-
-          if (resp?.error) {
-            return { error: resp.error };
-          }
-
-          return resp;
-      }
-    } else {
-      // prefer passkey in favor of other methods
-      if (methods.authMethodTypes.includes(AuthenticationMethodType.PASSKEY)) {
-        const passkeyParams = new URLSearchParams({
-          loginName: session.factors?.user?.loginName,
-          altPassword: `${methods.authMethodTypes.includes(AuthenticationMethodType.PASSWORD) && userLoginSettings?.allowUsernamePassword}`, // show alternative password option only if allowed
-        });
-
-        if (command.requestId) {
-          passkeyParams.append("requestId", command.requestId);
-        }
-
-        if (organization) {
-          passkeyParams.append("organization", organization);
-        }
-
-        return { redirect: "/passkey?" + passkeyParams };
-      } else if (methods.authMethodTypes.includes(AuthenticationMethodType.IDP)) {
-        return redirectUserToIDP(userId, organization);
-      } else if (methods.authMethodTypes.includes(AuthenticationMethodType.PASSWORD)) {
-        // Check if password authentication is allowed
-        if (!userLoginSettings?.allowUsernamePassword) {
-          return {
-            error:
-              "Username Password not allowed! Contact your administrator for more information.",
-          };
-        }
-
-        // user has no passkey setup and login settings allow passwords
-        const paramsPasswordDefault = new URLSearchParams({
-          loginName: session.factors?.user?.loginName,
-        });
-
-        if (command.requestId) {
-          paramsPasswordDefault.append("requestId", command.requestId);
-        }
-
-        if (organization) {
-          paramsPasswordDefault.append("organization", organization);
-        }
-
-        return {
-          redirect: "/password?" + paramsPasswordDefault,
-        };
-      }
-    }
+  if ("error" in sessionOrError) {
+    return sessionOrError;
   }
 
-  console.log("user not found (0 potential users), checking registration options");
+  const session = sessionOrError;
 
-  // user not found, perform organization discovery if no org context provided
-  let discoveredOrganization = command.organization;
-  let effectiveLoginSettings = loginSettingsByContext;
-
-  if (!discoveredOrganization && command.loginName && ORG_SUFFIX_REGEX.test(command.loginName)) {
-    const matched = ORG_SUFFIX_REGEX.exec(command.loginName);
-    const suffix = matched?.[1] ?? "";
-
-    // this just returns orgs where the suffix is set as primary domain
-    const orgs = await getOrgsByDomain({
-      serviceUrl,
-      domain: suffix,
-    });
-
-    const orgToCheckForDiscovery =
-      orgs.result && orgs.result.length === 1 ? orgs.result[0].id : undefined;
-
-    if (orgToCheckForDiscovery) {
-      const orgLoginSettings = await getLoginSettings({
-        serviceUrl,
-        organization: orgToCheckForDiscovery,
-      });
-
-      if (orgLoginSettings?.allowDomainDiscovery) {
-        console.log("org discovery successful, using org:", orgToCheckForDiscovery);
-        discoveredOrganization = orgToCheckForDiscovery;
-        // Use the discovered organization's login settings for subsequent checks
-        effectiveLoginSettings = orgLoginSettings;
-      } else {
-        console.log("org does not allow domain discovery");
-      }
-    } else {
-      console.log("no single org found for discovery");
-    }
+  if (!session.factors?.user?.id) {
+    return { error: t("errors.couldNotCreateSession") };
   }
 
-  // user not found, check if register is enabled on instance / organization context
-  if (effectiveLoginSettings?.allowRegister && !effectiveLoginSettings?.allowUsernamePassword) {
-    console.log("redirecting to IDP (register allowed, password not allowed)");
-    const resp = await redirectUserToIDP(undefined, discoveredOrganization);
-    if (resp) {
-      return resp;
-    }
-    console.log("IDP redirect failed, returning user not found");
-    return { error: t("errors.userNotFound") };
-  } else if (
-    effectiveLoginSettings?.allowRegister &&
-    effectiveLoginSettings?.allowUsernamePassword
-  ) {
-    console.log("register and password both allowed");
-    // do not register user if ignoreUnknownUsernames is set
-    if (discoveredOrganization && !effectiveLoginSettings?.ignoreUnknownUsernames) {
-      console.log("redirecting to registration page with org:", discoveredOrganization);
-      const params = new URLSearchParams({ organization: discoveredOrganization });
-
-      if (command.requestId) {
-        params.set("requestId", command.requestId);
-      }
-
-      if (command.loginName) {
-        params.set("email", command.loginName);
-      }
-
-      return { redirect: "/register?" + params };
-    } else {
-      console.log("not redirecting to register:", {
-        hasDiscoveredOrg: !!discoveredOrganization,
-        ignoreUnknownUsernames: effectiveLoginSettings?.ignoreUnknownUsernames,
-      });
-    }
+  // TODO: check if handling of userstate INITIAL is needed
+  if (user.state === UserState.INITIAL) {
+    return { error: t("errors.initialUserNotSupported") };
   }
 
-  if (effectiveLoginSettings?.ignoreUnknownUsernames) {
-    console.log("ignoreUnknownUsernames is true, redirecting to password");
-    const paramsPasswordDefault = new URLSearchParams({
-      loginName: command.loginName,
-    });
+  const methods = await listAuthenticationMethodTypes({
+    serviceUrl,
+    userId: session.factors?.user?.id,
+  });
 
-    if (command.requestId) {
-      paramsPasswordDefault.append("requestId", command.requestId);
-    }
-
-    if (discoveredOrganization) {
-      paramsPasswordDefault.append("organization", discoveredOrganization);
-    }
-
-    return { redirect: "/password?" + paramsPasswordDefault };
+  if (methods.authMethodTypes.includes(AuthenticationMethodType.PASSWORD)) {
+    return { redirect: "/password" };
   }
 
-  console.log("no valid registration option found, returning user not found");
-  return { error: t("errors.userNotFound") };
+  return { redirect: "/register" };
 }


### PR DESCRIPTION
# Summary

Refactored `username.ts` to simplify the login flow by removing features that are not needed for our use case.

## Changes

### Removed Functionality

- **IDP (Identity Provider) Support** - Removed the `redirectUserToIDP` function (~80 lines) and all IDP-related logic including `listIDPLinks`, `getIDPByID`, `getActiveIdentityProviders`, `startIdentityProviderFlow`, and IDP type conversions
- **Passkey Authentication** - Removed handling for `AuthenticationMethodType.PASSKEY` and `PasskeysType` settings
- **Organization Discovery** - Removed `ORG_SUFFIX_REGEX` and logic that discovers organizations from email domain suffixes via `getOrgsByDomain`
- **Login Settings Validation** - Removed checks for:
  - `disableLoginWithEmail` / `disableLoginWithPhone`
  - `allowUsernamePassword`
  - `allowRegister`
  - `ignoreUnknownUsernames`
  - `allowDomainDiscovery`
- **Invite/Verification Flow** - Removed redirect to `/verify` when user has no auth methods
- **Multi-method Handling** - Removed logic for users with multiple auth methods (e.g., preferring passkey over password)

### Simplified Flow

The new version:
1. Searches for users by login name
2. If user found → creates session → redirects to `/password` if PASSWORD auth method available, otherwise `/register`
3. If no user found → redirects to `/register`

### Other Changes

- Replaced `console.log` with `logMessage` from `@lib/logger`
- Removed redundant `users.length > 1` check (already handled in `searchUsers`)
- Flattened control flow with early returns
- Query parameters (organization, requestId) are no longer passed to redirect URLs

### Impact

~65% reduction in code (~350 → ~120 lines)