### PR TITLE
chore: add style tag for font path

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -40,6 +40,22 @@ export default async function Layout({ children }: { children: React.ReactNode }
           type="image/x-icon"
           sizes="32x32"
         />
+        {process.env.NEXT_PUBLIC_BASE_PATH && (
+          <style>
+            {`@font-face {
+  font-family: "gcds-icons";
+  src: url("${process.env.NEXT_PUBLIC_BASE_PATH}/fonts/icons/gcds-icons.eot");
+  src:
+    url("${process.env.NEXT_PUBLIC_BASE_PATH}/fonts/icons/gcds-icons.eot#iefix") format("embedded-opentype"),
+    url("${process.env.NEXT_PUBLIC_BASE_PATH}/fonts/icons/gcds-icons.ttf") format("truetype"),
+    url("${process.env.NEXT_PUBLIC_BASE_PATH}/fonts/icons/gcds-icons.woff") format("woff"),
+    url("${process.env.NEXT_PUBLIC_BASE_PATH}/fonts/icons/gcds-icons.svg") format("svg");
+  font-weight: normal;
+  font-style: normal;
+  font-display: block;
+}`}
+          </style>
+        )}
       </head>
 
       <body>{children} </body>


### PR DESCRIPTION
# Summary | Résumé

Fixes path issue for fonts

<img width="1089" height="710" alt="Screenshot 2026-02-18 at 12 38 24 PM" src="https://github.com/user-attachments/assets/2dd40052-6c40-43a6-94cd-a9dfc549acf1" />
