### PR TITLE
chore: add route level protection

### DIFF
--- a/lib/middleware-config.ts
+++ b/lib/middleware-config.ts
@@ -27,6 +27,9 @@ export const ROUTE_PATTERNS: Record<string, AuthLevel> = {
 
   // MFA setup - requires basic session
   "/mfa/set": AuthLevel.BASIC_SESSION,
+
+  // Completion page - requires basic session (uses getSessionCredentials)
+  "/all-set": AuthLevel.BASIC_SESSION,
 };
 
 /**
@@ -35,9 +38,8 @@ export const ROUTE_PATTERNS: Record<string, AuthLevel> = {
 export const PUBLIC_ROUTES = [
   "/", // Login/username entry
   "/login", // OIDC/SAML initiation
-  "/register", // User registration
-  "/register/password", // Registration password setup
-  "/password/reset", // Password reset request
+  "/register", // User registratio (accessed via email link with userId)
+  "/verify/success", // Email verification successsword reset request
   "/verify", // Email verification
   "/verify/success", // Email verification success
   "/all-set", // Completion page

--- a/lib/middleware-config.ts
+++ b/lib/middleware-config.ts
@@ -1,0 +1,121 @@
+import { AuthLevel } from "./server/route-protection";
+
+/**
+ * Route patterns mapped to their required authentication levels
+ */
+export const ROUTE_PATTERNS: Record<string, AuthLevel> = {
+  // Account management - requires full authentication with strong MFA
+  "/account": AuthLevel.STRONG_MFA_REQUIRED,
+
+  // Password change - requires password to be verified
+  "/password/change": AuthLevel.PASSWORD_REQUIRED,
+
+  // MFA selection (during auth flow) - requires password
+  "/mfa": AuthLevel.PASSWORD_REQUIRED,
+
+  // Password entry - requires basic session
+  "/password": AuthLevel.BASIC_SESSION,
+
+  // Password set (new users) - requires basic session
+  "/password/set": AuthLevel.BASIC_SESSION,
+
+  // OTP verification pages - require basic session
+  "/otp": AuthLevel.BASIC_SESSION,
+
+  // U2F verification - requires basic session
+  "/u2f": AuthLevel.BASIC_SESSION,
+
+  // MFA setup - requires basic session
+  "/mfa/set": AuthLevel.BASIC_SESSION,
+};
+
+/**
+ * Fully open routes - no authentication required
+ */
+export const PUBLIC_ROUTES = [
+  "/", // Login/username entry
+  "/login", // OIDC/SAML initiation
+  "/register", // User registration
+  "/register/password", // Registration password setup
+  "/password/reset", // Password reset request
+  "/verify", // Email verification
+  "/verify/success", // Email verification success
+  "/all-set", // Completion page
+  "/healthy", // Health check
+  "/security", // Security settings (cached)
+  "/logout-session", // Session termination
+  "/error", // Error pages
+];
+
+/**
+ * Routes that are part of multi-step authentication flows
+ * These routes may need special handling to preserve flow state
+ */
+export const AUTH_FLOW_ROUTES = [
+  "/password",
+  "/password/set",
+  "/mfa",
+  "/mfa/set",
+  "/otp/time-based",
+  "/otp/sms",
+  "/otp/email",
+  "/otp/time-based/set",
+  "/otp/sms/set",
+  "/otp/email/set",
+  "/u2f",
+  "/u2f/set",
+  "/verify",
+];
+
+/**
+ * Routes requiring strict validation at both middleware and page level
+ * These are high-value targets that need defense in depth
+ */
+export const STRICT_ROUTES = ["/account", "/password/change"];
+
+/**
+ * API routes that should not be processed by auth middleware
+ * (Static assets and Next.js internals are already excluded by matcher)
+ */
+export const API_ROUTES = ["/api", "/healthy", "/security", "/login", "/logout-session"];
+
+/**
+ * Check if a pathname matches any pattern in a list
+ */
+export function matchesPattern(pathname: string, patterns: string[]): boolean {
+  return patterns.some((pattern) => {
+    if (pattern.endsWith("*")) {
+      // Wildcard match
+      const prefix = pattern.slice(0, -1);
+      return pathname.startsWith(prefix);
+    }
+    return pathname === pattern || pathname.startsWith(pattern + "/");
+  });
+}
+
+/**
+ * Get the required authentication level for a given pathname
+ * Returns AuthLevel.OPEN for public routes
+ */
+export function getRequiredAuthLevel(pathname: string): AuthLevel {
+  // Check if it's a public route
+  if (matchesPattern(pathname, PUBLIC_ROUTES)) {
+    return AuthLevel.OPEN;
+  }
+
+  // Check exact matches first
+  if (pathname in ROUTE_PATTERNS) {
+    return ROUTE_PATTERNS[pathname];
+  }
+
+  // Check for prefix matches (e.g., /account/settings matches /account)
+  for (const [pattern, level] of Object.entries(ROUTE_PATTERNS)) {
+    if (pathname.startsWith(pattern + "/")) {
+      return level;
+    }
+  }
+
+  // Default to open for unmatched routes
+  // In production, you might want to default to BASIC_SESSION for safety
+  return AuthLevel.OPEN;
+}

--- a/lib/server/route-protection.ts
+++ b/lib/server/route-protection.ts
@@ -1,0 +1,273 @@
+import { getSession } from "@lib/zitadel";
+import { getMostRecentCookieWithLoginname } from "@lib/cookies";
+import { Session } from "@zitadel/proto/zitadel/session/v2/session_pb";
+import { timestampDate } from "@zitadel/client";
+import { logMessage } from "@lib/logger";
+import { ZITADEL_ORGANIZATION } from "@root/constants/config";
+
+/**
+ * Authentication levels for route protection
+ */
+export enum AuthLevel {
+  OPEN = "open", // No authentication required
+  BASIC_SESSION = "basic_session", // Session cookie must exist
+  PASSWORD_REQUIRED = "password_required", // Password factor verified
+  ANY_MFA_REQUIRED = "any_mfa_required", // Password + any MFA (TOTP, U2F, or OTP Email)
+  STRONG_MFA_REQUIRED = "strong_mfa_required", // Password + strong MFA (TOTP or U2F only)
+}
+
+/**
+ * Result of authentication level check
+ */
+export type AuthCheckResult = {
+  satisfied: boolean;
+  session?: Session | null;
+  redirect?: string;
+  reason?: string;
+};
+
+/**
+ * Extract session from cookies without throwing errors
+ * Returns null if session doesn't exist or is invalid
+ */
+export async function getSessionFromCookies(
+  serviceUrl: string,
+  loginName?: string,
+  organization?: string
+): Promise<Session | null> {
+  try {
+    const sessionCookie = await getMostRecentCookieWithLoginname({
+      loginName,
+      organization,
+    });
+
+    if (!sessionCookie?.id || !sessionCookie?.token) {
+      return null;
+    }
+
+    const response = await getSession({
+      serviceUrl,
+      sessionId: sessionCookie.id,
+      sessionToken: sessionCookie.token,
+    });
+
+    return response?.session || null;
+  } catch (error) {
+    logMessage.debug({
+      error,
+      message: "Failed to get session from cookies",
+      loginName,
+      organization,
+    });
+    return null;
+  }
+}
+
+/**
+ * Check if session has required authentication factors
+ */
+export function checkSessionFactors(session: Session | null) {
+  if (!session) {
+    return {
+      hasUser: false,
+      notExpired: false,
+      passwordVerified: false,
+      totpVerified: false,
+      u2fVerified: false,
+      otpEmailVerified: false,
+      emailVerified: false,
+    };
+  }
+
+  const hasUser = !!session.factors?.user?.id;
+  const notExpired = session.expirationDate
+    ? timestampDate(session.expirationDate).getTime() > new Date().getTime()
+    : true;
+
+  const passwordVerified = !!session.factors?.password?.verifiedAt;
+  const totpVerified = !!session.factors?.totp?.verifiedAt;
+  const u2fVerified = !!session.factors?.webAuthN?.verifiedAt;
+  const otpEmailVerified = !!session.factors?.otpEmail?.verifiedAt;
+
+  // Email verification would require fetching user data, skip for now
+  const emailVerified = false;
+
+  return {
+    hasUser,
+    notExpired,
+    passwordVerified,
+    totpVerified,
+    u2fVerified,
+    otpEmailVerified,
+    emailVerified,
+  };
+}
+
+/**
+ * Check if session has strong MFA (TOTP or U2F)
+ */
+export function hasStrongMFA(session: Session | null): boolean {
+  if (!session) return false;
+  const factors = checkSessionFactors(session);
+  return factors.totpVerified || factors.u2fVerified;
+}
+
+/**
+ * Check if session has any MFA (TOTP, U2F, or OTP Email)
+ */
+export function hasAnyMFA(session: Session | null): boolean {
+  if (!session) return false;
+  const factors = checkSessionFactors(session);
+  return factors.totpVerified || factors.u2fVerified || factors.otpEmailVerified;
+}
+
+/**
+ * Check if authentication level is satisfied
+ */
+export async function checkAuthenticationLevel(
+  serviceUrl: string,
+  requiredLevel: AuthLevel,
+  loginName?: string,
+  organization?: string
+): Promise<AuthCheckResult> {
+  // Open routes always pass
+  if (requiredLevel === AuthLevel.OPEN) {
+    return { satisfied: true };
+  }
+
+  // Get session from cookies
+  const session = await getSessionFromCookies(serviceUrl, loginName, organization);
+
+  // Basic session check - just verify cookie exists
+  if (requiredLevel === AuthLevel.BASIC_SESSION) {
+    if (!session) {
+      return {
+        satisfied: false,
+        redirect: "/",
+        reason: "No session found",
+      };
+    }
+    return { satisfied: true, session };
+  }
+
+  // For password and MFA checks, verify session factors
+  const factors = checkSessionFactors(session);
+
+  if (!factors.hasUser || !factors.notExpired) {
+    return {
+      satisfied: false,
+      session,
+      redirect: "/",
+      reason: factors.hasUser ? "Session expired" : "No user in session",
+    };
+  }
+
+  // Password required check
+  if (requiredLevel === AuthLevel.PASSWORD_REQUIRED) {
+    if (!factors.passwordVerified) {
+      return {
+        satisfied: false,
+        session,
+        redirect: "/password",
+        reason: "Password not verified",
+      };
+    }
+    return { satisfied: true, session };
+  }
+
+  // Any MFA required check
+  if (requiredLevel === AuthLevel.ANY_MFA_REQUIRED) {
+    if (!factors.passwordVerified) {
+      return {
+        satisfied: false,
+        session,
+        redirect: "/password",
+        reason: "Password not verified",
+      };
+    }
+    if (!hasAnyMFA(session)) {
+      return {
+        satisfied: false,
+        session,
+        redirect: "/mfa",
+        reason: "MFA not verified",
+      };
+    }
+    return { satisfied: true, session };
+  }
+
+  // Strong MFA required check
+  if (requiredLevel === AuthLevel.STRONG_MFA_REQUIRED) {
+    if (!factors.passwordVerified) {
+      return {
+        satisfied: false,
+        session,
+        redirect: "/password",
+        reason: "Password not verified",
+      };
+    }
+    if (!hasStrongMFA(session)) {
+      return {
+        satisfied: false,
+        session,
+        redirect: "/mfa",
+        reason: "Strong MFA not verified",
+      };
+    }
+    return { satisfied: true, session };
+  }
+
+  return { satisfied: false, reason: "Unknown auth level" };
+}
+
+/**
+ * Get smart redirect URL based on current auth state and destination
+ * Preserves requestId and organization params
+ */
+export function getSmartRedirect(
+  destinationPath: string,
+  session: Session | null,
+  searchParams?: URLSearchParams
+): string {
+  const factors = checkSessionFactors(session);
+  const params = new URLSearchParams();
+
+  // Preserve important params
+  if (searchParams) {
+    const requestId = searchParams.get("requestId");
+    const loginName = searchParams.get("loginName");
+
+    if (requestId) params.set("requestId", requestId);
+    if (loginName) params.set("loginName", loginName);
+  }
+
+  // Always set organization to hardcoded value
+  params.set("organization", ZITADEL_ORGANIZATION);
+
+  // Extract loginName from session if available
+  if (!params.has("loginName") && session?.factors?.user?.loginName) {
+    params.set("loginName", session.factors.user.loginName);
+  }
+
+  // No session at all - go to login
+  if (!session || !factors.hasUser || !factors.notExpired) {
+    const queryString = params.toString();
+    return queryString ? `/?${queryString}` : "/";
+  }
+
+  // Has session but no password - go to password entry
+  if (!factors.passwordVerified) {
+    const queryString = params.toString();
+    return queryString ? `/password?${queryString}` : "/password";
+  }
+
+  // Has password but needs MFA for destination - go to MFA check
+  if (!hasStrongMFA(session)) {
+    const queryString = params.toString();
+    return queryString ? `/mfa?${queryString}` : "/mfa";
+  }
+
+  // All factors satisfied but still redirecting - something's wrong
+  // Fall back to account page as safe destination
+  return "/account";
+}

--- a/lib/server/verify.ts
+++ b/lib/server/verify.ts
@@ -293,7 +293,11 @@ export async function sendVerificationEmail(command: SendVerificationEmailComman
 
   try {
     const gcNotify = GCNotifyConnector.default(apiKey);
-    await gcNotify.sendEmail(email, templateId, getSecurityCodeTemplate(codeResponse.verificationCode));
+    await gcNotify.sendEmail(
+      email,
+      templateId,
+      getSecurityCodeTemplate(codeResponse.verificationCode)
+    );
 
     return { success: true };
   } catch (error) {

--- a/proxy.ts
+++ b/proxy.ts
@@ -3,15 +3,31 @@ import { SecuritySettings } from "@zitadel/proto/zitadel/settings/v2/security_se
 import { headers } from "next/headers";
 import { NextRequest, NextResponse } from "next/server";
 import { DEFAULT_CSP } from "./constants/csp";
+import { ZITADEL_ORGANIZATION } from "@root/constants/config";
 import { getServiceUrlFromHeaders } from "./lib/service-url";
+import {
+  getRequiredAuthLevel,
+  matchesPattern,
+  API_ROUTES,
+  AUTH_FLOW_ROUTES,
+} from "./lib/middleware-config";
+import {
+  AuthLevel,
+  checkAuthenticationLevel,
+  getSmartRedirect,
+} from "./lib/server/route-protection";
+
 export const config = {
   matcher: [
-    "/.well-known/:path*",
-    "/oauth/:path*",
-    "/oidc/:path*",
-    "/idps/callback/:path*",
-    "/saml/:path*",
-    "/:path*",
+    /*
+     * Match all request paths except:
+     * - _next/static (static files)
+     * - _next/image (image optimization)
+     * - favicon.ico (favicon file)
+     * - public folder files
+     * - files with extensions (images, fonts, etc.)
+     */
+    "/((?!_next/static|_next/image|favicon.ico|.*\\..*|img/).*)",
   ],
 };
 
@@ -38,58 +54,138 @@ async function loadSecuritySettings(request: NextRequest): Promise<SecuritySetti
 }
 
 export async function proxy(request: NextRequest) {
+  const { pathname, searchParams } = request.nextUrl;
+
   // Add the original URL as a header to all requests
   const requestHeaders = new Headers(request.headers);
 
-  // Extract "organization" search param from the URL and set it as a header if available
-  const organization = request.nextUrl.searchParams.get("organization");
-  if (organization) {
-    requestHeaders.set("x-zitadel-i18n-organization", organization);
+  // Set organization header for Zitadel
+  requestHeaders.set("x-zitadel-i18n-organization", ZITADEL_ORGANIZATION);
+
+  // Only run the proxy logic for OIDC/SAML paths
+  const proxyPaths = ["/.well-known/", "/oauth/", "/oidc/", "/idps/callback/", "/saml/"];
+  const isProxyPath = proxyPaths.some((prefix) => pathname.startsWith(prefix));
+
+  // Handle OIDC/SAML proxy paths
+  if (isProxyPath) {
+    // escape proxy if the environment is not setup for multitenancy
+    if (!process.env.ZITADEL_API_URL || !process.env.ZITADEL_SERVICE_USER_TOKEN) {
+      return NextResponse.next({
+        request: { headers: requestHeaders },
+      });
+    }
+
+    const _headers = await headers();
+    const { serviceUrl } = getServiceUrlFromHeaders(_headers);
+
+    const instanceHost = `${serviceUrl}`.replace("https://", "").replace("http://", "");
+
+    // Add additional headers for proxy
+    requestHeaders.set("x-zitadel-public-host", `https://${_headers.get("host")}`);
+    requestHeaders.set("x-zitadel-instance-host", instanceHost);
+
+    const responseHeaders = new Headers();
+    responseHeaders.set("Access-Control-Allow-Origin", "*");
+    responseHeaders.set("Access-Control-Allow-Headers", "*");
+
+    const securitySettings = await loadSecuritySettings(request);
+
+    if (securitySettings?.embeddedIframe?.enabled) {
+      responseHeaders.set(
+        "Content-Security-Policy",
+        `${DEFAULT_CSP} frame-ancestors ${securitySettings.embeddedIframe.allowedOrigins.join(" ")};`
+      );
+      responseHeaders.delete("X-Frame-Options");
+    }
+
+    request.nextUrl.href = `${serviceUrl}${pathname}${request.nextUrl.search}`;
+
+    return NextResponse.rewrite(request.nextUrl, {
+      request: {
+        headers: requestHeaders,
+      },
+      headers: responseHeaders,
+    });
   }
 
-  // Only run the rest of the logic for the original matcher paths
-  const proxyPaths = ["/.well-known/", "/oauth/", "/oidc/", "/idps/callback/", "/saml/"];
-
-  const isMatched = proxyPaths.some((prefix) => request.nextUrl.pathname.startsWith(prefix));
-
-  // escape proxy if the environment is setup for multitenancy
-  if (!isMatched || !process.env.ZITADEL_API_URL || !process.env.ZITADEL_SERVICE_USER_TOKEN) {
-    // For all other routes, just add the header and continue
+  // Skip auth checks for API routes
+  if (matchesPattern(pathname, API_ROUTES)) {
     return NextResponse.next({
       request: { headers: requestHeaders },
     });
   }
 
+  // Get service URL for auth checks
   const _headers = await headers();
   const { serviceUrl } = getServiceUrlFromHeaders(_headers);
 
-  const instanceHost = `${serviceUrl}`.replace("https://", "").replace("http://", "");
+  // Determine required authentication level for this route
+  const requiredLevel = getRequiredAuthLevel(pathname);
 
-  // Add additional headers as before
-  requestHeaders.set("x-zitadel-public-host", `https://${_headers.get("host")}`);
-  requestHeaders.set("x-zitadel-instance-host", instanceHost);
-  // requestHeaders.set("x-zitadel-forward-host", `https://${_headers.get("host")}`);
-
-  const responseHeaders = new Headers();
-  responseHeaders.set("Access-Control-Allow-Origin", "*");
-  responseHeaders.set("Access-Control-Allow-Headers", "*");
-
-  const securitySettings = await loadSecuritySettings(request);
-
-  if (securitySettings?.embeddedIframe?.enabled) {
-    responseHeaders.set(
-      "Content-Security-Policy",
-      `${DEFAULT_CSP} frame-ancestors ${securitySettings.embeddedIframe.allowedOrigins.join(" ")};`
-    );
-    responseHeaders.delete("X-Frame-Options");
+  // Skip check for open routes
+  if (requiredLevel === AuthLevel.OPEN) {
+    return NextResponse.next({
+      request: { headers: requestHeaders },
+    });
   }
 
-  request.nextUrl.href = `${serviceUrl}${request.nextUrl.pathname}${request.nextUrl.search}`;
+  // Check authentication level (loginName will be extracted from session cookie)
+  const authCheck = await checkAuthenticationLevel(
+    serviceUrl,
+    requiredLevel,
+    undefined, // loginName extracted from session cookie
+    ZITADEL_ORGANIZATION
+  );
 
-  return NextResponse.rewrite(request.nextUrl, {
-    request: {
-      headers: requestHeaders,
-    },
-    headers: responseHeaders,
-  });
+  // If satisfied, allow the request
+  if (authCheck.satisfied) {
+    return NextResponse.next({
+      request: { headers: requestHeaders },
+    });
+  }
+
+  // Special handling for auth flow routes
+  // Allow partial authentication if user is progressing through multi-step flows
+  // This works both with OIDC flows (requestId present) and standalone auth
+  const isAuthFlowRoute = matchesPattern(pathname, AUTH_FLOW_ROUTES);
+
+  if (isAuthFlowRoute) {
+    // Allow access to MFA pages if password is verified
+    if (pathname.startsWith("/mfa") || pathname.startsWith("/otp") || pathname.startsWith("/u2f")) {
+      const session = authCheck.session;
+      const hasPassword = session?.factors?.password?.verifiedAt;
+
+      if (hasPassword) {
+        // Allow access to MFA flow pages when password is already verified
+        return NextResponse.next({
+          request: { headers: requestHeaders },
+        });
+      }
+    }
+
+    // Allow access to password pages if session exists
+    if (pathname.startsWith("/password")) {
+      if (authCheck.session?.factors?.user) {
+        return NextResponse.next({
+          request: { headers: requestHeaders },
+        });
+      }
+    }
+  }
+
+  // Not satisfied and no special case applies - redirect
+  const redirectUrl = getSmartRedirect(pathname, authCheck.session || null, searchParams);
+
+  const url = request.nextUrl.clone();
+  url.pathname = redirectUrl.split("?")[0];
+
+  // Preserve query params from smart redirect
+  if (redirectUrl.includes("?")) {
+    const redirectParams = new URLSearchParams(redirectUrl.split("?")[1]);
+    redirectParams.forEach((value, key) => {
+      url.searchParams.set(key, value);
+    });
+  }
+
+  return NextResponse.redirect(url);
 }


### PR DESCRIPTION
# Summary | Résumé

Add:

Authentication hierarchy for various page requirements:

- **OPEN**: No authentication required (login, register, verify pages)
- **BASIC_SESSION**: Session cookie must exist (password entry, MFA setup)
- **PASSWORD_REQUIRED**: Password factor verified (password change, MFA selection)
- **ANY_MFA_REQUIRED**: Password + any MFA (TOTP, U2F, or OTP Email)
- **STRONG_MFA_REQUIRED**: Password + strong MFA only (TOTP or U2F) - Account management

Adds config for route mapping

- `ROUTE_PATTERNS` - Maps routes to required AuthLevel
- `PUBLIC_ROUTES` - Fully open routes (login etc.)
- `AUTH_FLOW_ROUTES` - Multi-step authentication flow routes
- `STRICT_ROUTES` - Routes requiring page-level double-check
- `API_ROUTES` - Routes excluded from auth checks

Adds matchers and auth checks for routes.

**Execution Flow:**
1. Set organization header to `ZITADEL_ORGANIZATION` constant
2. Proxy OIDC/SAML paths → Forward to Zitadel (/.well-known/, /oauth/, etc.)
3. Skip auth for API routes → Pass through (/api, /healthy, etc.)
4. Determine required auth level → Use middleware-config
5. Check authentication → Validate session and factors
6. Progressive flow handling → Allow MFA pages if password verified
7. Redirect ...→ Guide to next required step