### PR TITLE
chore: password reset fixes

### DIFF
--- a/app/(auth)/password/reset/components/PasswordReset.tsx
+++ b/app/(auth)/password/reset/components/PasswordReset.tsx
@@ -29,6 +29,12 @@ export function PasswordReset({
   const { t } = useTranslation(["password"]);
   const router = useRouter();
   const [error, setError] = useState("");
+  const [formResetKey, setFormResetKey] = useState(0);
+
+  const setErrorAndResetForm = (message: string) => {
+    setError(message);
+    setFormResetKey((previous) => previous + 1);
+  };
 
   const submitPasswordForm = async ({ password, code }: { password: string; code?: string }) => {
     const payload: { userId: string; password: string; code?: string } = {
@@ -37,17 +43,17 @@ export function PasswordReset({
       ...(code ? { code } : {}),
     };
 
-    const changeResponse = await changePassword(payload).catch(() =>
-      setError("rest.errors.couldNotSetPassword")
-    );
+    const changeResponse = await changePassword(payload).catch(() => {
+      setErrorAndResetForm(t("reset.errors.couldNotSetPassword"));
+    });
 
     if (changeResponse && "error" in changeResponse) {
-      setError(changeResponse.error);
+      setErrorAndResetForm(changeResponse.error);
       return;
     }
 
     if (!changeResponse) {
-      setError(t("reset.errors.couldNotSetPassword"));
+      setErrorAndResetForm(t("reset.errors.couldNotSetPassword"));
       return;
     }
 
@@ -57,10 +63,12 @@ export function PasswordReset({
       checks: create(ChecksSchema, {
         password: { password },
       }),
-    }).catch(() => setError(t("reset.errors.couldNotVerifyPassword")));
+    }).catch(() => {
+      setErrorAndResetForm(t("reset.errors.couldNotVerifyPassword"));
+    });
 
     if (passwordResponse && "error" in passwordResponse && passwordResponse.error) {
-      setError(passwordResponse.error);
+      setErrorAndResetForm(passwordResponse.error);
       return;
     }
 
@@ -77,6 +85,7 @@ export function PasswordReset({
     <>
       {error && <Alert type={ErrorStatus.ERROR}>{error}</Alert>}
       <PasswordValidationForm
+        key={formResetKey}
         passwordComplexitySettings={passwordComplexitySettings}
         successCallback={submitPasswordForm}
         requireConfirmationCode={true}

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -210,6 +210,7 @@
       }
     },
     "complexity": {
+      "required": "This field is required.",
       "requiredPassword": "Password is required.",
       "requiredConfirmPassword": "Confirm password is required.",
       "minLength": "At least 8 characters",
@@ -231,6 +232,11 @@
       "submit": "Continue",
       "labels": {
         "confirmationCode": "Confirmation code"
+      },
+      "errors": {
+        "missingRequiredInformation": "Missing required information",
+        "couldNotSetPassword": "Could not set password",
+        "couldNotVerifyPassword": "Could not verify password"
       }
     },
     "errors": {

--- a/i18n/locales/fr.json
+++ b/i18n/locales/fr.json
@@ -207,6 +207,7 @@
       }
     },
     "complexity": {
+      "required": "Ce champ est obligatoire.",
       "requiredPassword": "Le mot de passe est obligatoire.",
       "requiredConfirmPassword": "La confirmation du mot de passe est obligatoire.",
       "minLength": "Au moins 8 caractères",
@@ -228,6 +229,11 @@
       "submit": "Continuer",
       "labels": {
         "confirmationCode": "Code de confirmation"
+      },
+      "errors": {
+        "missingRequiredInformation": "Information requise manquante",
+        "couldNotSetPassword": "Le mot de passe n'a pas pu être défini.",
+        "couldNotVerifyPassword": "Le mot de passe n'a pas pu être vérifié."
       }
     },
     "errors": {
@@ -235,6 +241,8 @@
       "couldNotSendResetLink": "Problème d'envoi du lien de réinitialisation du mot de passe",
       "couldNotCreateSessionForUser": "Problème de création de session pour cet utilisateur",
       "couldNotVerifyPassword": "Problème de vérification du mot de passe",
+      "couldNotResetPassword": "Le mot de passe n'a pas pu être réinitialisé",
+      "couldNotRegisterUser": "Le compte utilisateur n'a pas pu être créé",
       "failedToAuthenticate": "Échec de l'authentification. Vous avez essayé {failedAttempts} des {maxPasswordAttempts} tentatives de mot de passe. {lockoutMessage}",
       "failedToAuthenticateNoLimit": "Échec de l'authentification.",
       "accountLockedContactAdmin": " Contactez votre administrateur pour déverrouiller votre compte",


### PR DESCRIPTION
# Summary | Résumé

Fixes an issue where a missing session cookie was expected but handled incorrectly, leading to no-session or session-expired behaviour

- Explicitly handles the expected no-cookie path in reset auth and continues flow after creating a new session.
- Removes noisy expected-path warning behaviour tied to missing session cookie during fresh reset.

Adds an extra check to ensure password-changed notifications are only sent when the password was actually changed.

Updates the password complexity preview so it resets when password fields are cleared on the reset screen.

Adds missing translation keys used by reset and complexity validation states.

Updates anti-enumeration hardening for reset initiation.

- Reset initiation now returns a non-distinguishing response shape for non-success outcomes to avoid revealing whether an account exists.

- Added early empty `userId` guard and safe `getUserByID` handling.
- Invalid/missing user now returns a controlled generic reset error instead of throwing.
