### PR TITLE
chore: handle otp already exists error

### DIFF
--- a/app/(auth)/mfa/page.tsx
+++ b/app/(auth)/mfa/page.tsx
@@ -78,7 +78,7 @@ export default async function Page() {
           <UserAvatar
             loginName={loginName ?? sessionFactors.factors?.user?.loginName}
             displayName={sessionFactors.factors?.user?.displayName}
-            showDropdown
+            showDropdown={false}
           ></UserAvatar>
         </div>
         <ChooseSecondFactor

--- a/app/(auth)/otp/[method]/page.tsx
+++ b/app/(auth)/otp/[method]/page.tsx
@@ -82,7 +82,7 @@ export default async function Page(props: {
             <UserAvatar
               loginName={loginName ?? sessionFactors.factors?.user?.loginName}
               displayName={sessionFactors.factors?.user?.displayName}
-              showDropdown
+              showDropdown={false}
             />
           )}
         </LoginOTP>

--- a/app/(auth)/otp/[method]/set/page.tsx
+++ b/app/(auth)/otp/[method]/set/page.tsx
@@ -71,10 +71,12 @@ export default async function Page(props: {
     error: Error | undefined,
     mappedUiError: ReturnType<typeof getZitadelUiError>;
   if (session && session.factors?.user?.id) {
+    const userId = session.factors.user.id;
+
     if (method === "time-based") {
       await registerTOTP({
         serviceUrl,
-        userId: session.factors.user.id,
+        userId,
       })
         .then((resp) => {
           if (resp) {
@@ -124,6 +126,8 @@ export default async function Page(props: {
     urlToContinue = buildUrlWithRequestId(LOGGED_IN_HOME_PAGE, requestId);
   }
 
+  const shouldBlockContinue = Boolean(error) && (!mappedUiError || mappedUiError.blockContinue);
+
   return (
     <>
       <AuthPanel titleI18nKey="set.title" descriptionI18nKey="none" namespace="otp">
@@ -142,7 +146,7 @@ export default async function Page(props: {
               {mappedUiError ? (
                 <I18n i18nKey={mappedUiError.i18nKey} namespace="otp" />
               ) : (
-                <I18n i18nKey="title" namespace="error" />
+                <I18n i18nKey="set.genericError" namespace="otp" />
               )}
             </Alert.Warning>
           </div>
@@ -174,7 +178,7 @@ export default async function Page(props: {
             <BackButton />
             <span className="grow"></span>
 
-            {mappedUiError?.blockContinue ? (
+            {shouldBlockContinue ? (
               <Button disabled>
                 <I18n i18nKey="set.submit" namespace="otp" />
               </Button>

--- a/app/(auth)/otp/[method]/set/page.tsx
+++ b/app/(auth)/otp/[method]/set/page.tsx
@@ -140,7 +140,7 @@ export default async function Page(props: {
           <div className="py-4">
             <Alert.Warning>
               {mappedUiError ? (
-                <I18n i18nKey={mappedUiError.i18nKey} namespace={mappedUiError.namespace} />
+                <I18n i18nKey={mappedUiError.i18nKey} namespace="otp" />
               ) : (
                 <I18n i18nKey="title" namespace="error" />
               )}

--- a/app/(auth)/u2f/page.tsx
+++ b/app/(auth)/u2f/page.tsx
@@ -81,7 +81,7 @@ export default async function Page(props: { searchParams: Promise<SearchParams> 
         <UserAvatar
           loginName={loginName ?? sessionFactors.factors?.user?.loginName}
           displayName={sessionFactors.factors?.user?.displayName}
-          showDropdown
+          showDropdown={false}
         ></UserAvatar>
       )}
       <div className="w-full">

--- a/app/(auth)/verify/page.tsx
+++ b/app/(auth)/verify/page.tsx
@@ -78,7 +78,7 @@ export default async function Page(props: { searchParams: Promise<SearchParams> 
             <UserAvatar
               loginName={loginName ?? sessionFactors.factors?.user?.loginName}
               displayName={sessionFactors.factors?.user?.displayName}
-              showDropdown
+              showDropdown={false}
             ></UserAvatar>
           ) : (
             user && (

--- a/components/mfa/otp/TotpRegister.tsx
+++ b/components/mfa/otp/TotpRegister.tsx
@@ -37,7 +37,6 @@ export function TotpRegister({ uri, loginName, requestId, organization, checkAft
 
   const { t } = useTranslation("otp");
   const genericErrorMessage = t("title", { ns: "error" });
-  const alreadySetUpMessage = t("set.alreadySetUp");
 
   const localFormAction = async (previousState: FormState, formData?: FormData) => {
     const code = formData?.get("code");
@@ -72,13 +71,8 @@ export function TotpRegister({ uri, loginName, requestId, organization, checkAft
       })
       .catch((e) => {
         if (e instanceof Error) {
-          // Detect "already set up" error from Zitadel and map to user-friendly message
-          let errorMessage = e.message;
-          if (e.message?.includes("already set up") || e.message?.includes("Multifactor OTP")) {
-            errorMessage = alreadySetUpMessage;
-          }
           return {
-            error: errorMessage,
+            error: genericErrorMessage,
           };
         } else {
           throw e;
@@ -86,8 +80,6 @@ export function TotpRegister({ uri, loginName, requestId, organization, checkAft
       });
   };
   const [state, formAction] = useActionState(localFormAction, {});
-  const safeErrorMessage =
-    state.error === alreadySetUpMessage ? alreadySetUpMessage : genericErrorMessage;
 
   return (
     <div className="flex flex-col items-center">
@@ -110,7 +102,7 @@ export function TotpRegister({ uri, loginName, requestId, organization, checkAft
 
             {state.error && (
               <div className="py-4">
-                <Alert type={ErrorStatus.ERROR}>{safeErrorMessage}</Alert>
+                <Alert type={ErrorStatus.ERROR}>{state.error}</Alert>
               </div>
             )}
 

--- a/components/mfa/otp/TotpRegister.tsx
+++ b/components/mfa/otp/TotpRegister.tsx
@@ -13,6 +13,7 @@ import { QRCodeSVG } from "qrcode.react";
  *--------------------------------------------*/
 import { getSafeErrorMessage } from "@lib/safeErrorMessage";
 import { verifyTOTP } from "@lib/server/verify";
+import { getZitadelUiError } from "@lib/zitadel-errors";
 import { I18n, useTranslation } from "@i18n";
 import { SubmitButtonAction } from "@components/ui/button/SubmitButton";
 import { Alert, ErrorStatus, Label, TextInput } from "@components/ui/form";
@@ -36,8 +37,9 @@ type Props = {
 export function TotpRegister({ uri, loginName, requestId, organization, checkAfter }: Props) {
   const router = useRouter();
 
-  const { t } = useTranslation("otp");
-  const genericErrorMessage = t("title", { ns: "error" });
+  const { t } = useTranslation(["otp", "error"]);
+  const genericErrorMessage = t("error:title");
+  const invalidCodeMessage = t("set.invalidCode");
 
   const localFormAction = async (previousState: FormState, formData?: FormData) => {
     const code = formData?.get("code");
@@ -71,9 +73,16 @@ export function TotpRegister({ uri, loginName, requestId, organization, checkAft
         return previousState;
       })
       .catch((e) => {
+        const mappedUiError = getZitadelUiError("otp.set", e);
+        if (mappedUiError) {
+          return {
+            error: t(mappedUiError.i18nKey),
+          };
+        }
+
         if (e instanceof Error) {
           return {
-            error: e.message,
+            error: genericErrorMessage,
           };
         } else {
           throw e;
@@ -94,24 +103,24 @@ export function TotpRegister({ uri, loginName, requestId, organization, checkAft
             <CopyToClipboard value={uri}></CopyToClipboard>
           </div>
           <form className="w-full" action={formAction}>
-            <div className="gcds-input-wrapper">
-              <Label id={"label-code"} htmlFor={"code"} className="required" required>
-                {t("set.labels.code")}
-              </Label>
-              <TextInput type={"text"} id={"code"} required defaultValue={""} />
-            </div>
-
             {state.error && (
               <div className="py-4">
                 <Alert type={ErrorStatus.ERROR}>
                   {getSafeErrorMessage({
                     error: state.error,
                     fallback: genericErrorMessage,
-                    allowedMessages: [genericErrorMessage],
+                    allowedMessages: [genericErrorMessage, invalidCodeMessage],
                   })}
                 </Alert>
               </div>
             )}
+
+            <div className="gcds-input-wrapper">
+              <Label id={"label-code"} htmlFor={"code"} className="required" required>
+                {t("set.labels.code")}
+              </Label>
+              <TextInput type={"text"} id={"code"} required defaultValue={""} />
+            </div>
 
             <SubmitButtonAction>
               <I18n i18nKey="set.submit" namespace="otp" />

--- a/components/mfa/otp/TotpRegister.tsx
+++ b/components/mfa/otp/TotpRegister.tsx
@@ -36,6 +36,8 @@ export function TotpRegister({ uri, loginName, requestId, organization, checkAft
   const router = useRouter();
 
   const { t } = useTranslation("otp");
+  const genericErrorMessage = t("title", { ns: "error" });
+  const alreadySetUpMessage = t("set.alreadySetUp");
 
   const localFormAction = async (previousState: FormState, formData?: FormData) => {
     const code = formData?.get("code");
@@ -70,8 +72,13 @@ export function TotpRegister({ uri, loginName, requestId, organization, checkAft
       })
       .catch((e) => {
         if (e instanceof Error) {
+          // Detect "already set up" error from Zitadel and map to user-friendly message
+          let errorMessage = e.message;
+          if (e.message?.includes("already set up") || e.message?.includes("Multifactor OTP")) {
+            errorMessage = alreadySetUpMessage;
+          }
           return {
-            error: e.message,
+            error: errorMessage,
           };
         } else {
           throw e;
@@ -101,7 +108,9 @@ export function TotpRegister({ uri, loginName, requestId, organization, checkAft
 
             {state.error && (
               <div className="py-4">
-                <Alert type={ErrorStatus.ERROR}>{state.error}</Alert>
+                <Alert type={ErrorStatus.ERROR}>
+                  {state.error === alreadySetUpMessage ? alreadySetUpMessage : genericErrorMessage}
+                </Alert>
               </div>
             )}
 

--- a/components/mfa/otp/TotpRegister.tsx
+++ b/components/mfa/otp/TotpRegister.tsx
@@ -11,6 +11,7 @@ import { QRCodeSVG } from "qrcode.react";
 /*--------------------------------------------*
  * Internal Aliases
  *--------------------------------------------*/
+import { getSafeErrorMessage } from "@lib/safeErrorMessage";
 import { verifyTOTP } from "@lib/server/verify";
 import { I18n, useTranslation } from "@i18n";
 import { SubmitButtonAction } from "@components/ui/button/SubmitButton";
@@ -43,7 +44,7 @@ export function TotpRegister({ uri, loginName, requestId, organization, checkAft
 
     if (typeof code !== "string") {
       return {
-        error: "Invalid Field",
+        error: genericErrorMessage,
       };
     }
 
@@ -102,7 +103,13 @@ export function TotpRegister({ uri, loginName, requestId, organization, checkAft
 
             {state.error && (
               <div className="py-4">
-                <Alert type={ErrorStatus.ERROR}>{state.error}</Alert>
+                <Alert type={ErrorStatus.ERROR}>
+                  {getSafeErrorMessage({
+                    error: state.error,
+                    fallback: genericErrorMessage,
+                    allowedMessages: [genericErrorMessage],
+                  })}
+                </Alert>
               </div>
             )}
 

--- a/components/mfa/otp/TotpRegister.tsx
+++ b/components/mfa/otp/TotpRegister.tsx
@@ -73,7 +73,7 @@ export function TotpRegister({ uri, loginName, requestId, organization, checkAft
       .catch((e) => {
         if (e instanceof Error) {
           return {
-            error: genericErrorMessage,
+            error: e.message,
           };
         } else {
           throw e;

--- a/components/mfa/otp/TotpRegister.tsx
+++ b/components/mfa/otp/TotpRegister.tsx
@@ -8,7 +8,6 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { QRCodeSVG } from "qrcode.react";
 
-import { getSafeErrorMessage } from "@lib/safeErrorMessage";
 /*--------------------------------------------*
  * Internal Aliases
  *--------------------------------------------*/
@@ -87,6 +86,8 @@ export function TotpRegister({ uri, loginName, requestId, organization, checkAft
       });
   };
   const [state, formAction] = useActionState(localFormAction, {});
+  const safeErrorMessage =
+    state.error === alreadySetUpMessage ? alreadySetUpMessage : genericErrorMessage;
 
   return (
     <div className="flex flex-col items-center">
@@ -109,14 +110,7 @@ export function TotpRegister({ uri, loginName, requestId, organization, checkAft
 
             {state.error && (
               <div className="py-4">
-                <Alert type={ErrorStatus.ERROR}>
-                  {state.error === alreadySetUpMessage ? alreadySetUpMessage : genericErrorMessage}
-                  {getSafeErrorMessage({
-                    error: state.error,
-                    fallback: genericErrorMessage,
-                    allowedMessages: [genericErrorMessage],
-                  })}
-                </Alert>
+                <Alert type={ErrorStatus.ERROR}>{safeErrorMessage}</Alert>
               </div>
             )}
 

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -313,6 +313,7 @@
       "totpRegisterDescription": "Scan the QR Code or navigate to the URL link.",
       "submit": "Continue",
       "genericError": "We couldn’t set up your authenticator app right now. Please try again.",
+      "invalidCode": "The code is invalid. Please try again.",
       "alreadySetUp": "Your authenticator app is already configured on your account.",
       "labels": {
         "code": "Code"

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -312,6 +312,7 @@
       "emailDescription": "Enter your email address to receive a code via email.",
       "totpRegisterDescription": "Scan the QR Code or navigate to the URL link.",
       "submit": "Continue",
+      "genericError": "We couldn’t set up your authenticator app right now. Please try again.",
       "alreadySetUp": "Your authenticator app is already configured on your account.",
       "labels": {
         "code": "Code"

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -312,7 +312,7 @@
       "emailDescription": "Enter your email address to receive a code via email.",
       "totpRegisterDescription": "Scan the QR Code or navigate to the URL link.",
       "submit": "Continue",
-      "alreadySetUp": "Your authenticator app is already configured on your account. To change your verification method, remove the existing authenticator app setup from your account settings.",
+      "alreadySetUp": "Your authenticator app is already configured on your account.",
       "labels": {
         "code": "Code"
       },

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -306,6 +306,7 @@
       "emailDescription": "Enter your email address to receive a code via email.",
       "totpRegisterDescription": "Scan the QR Code or navigate to the URL link.",
       "submit": "Continue",
+      "alreadySetUp": "Your authenticator app is already configured on your account. To change your verification method, remove the existing authenticator app setup from your account settings.",
       "labels": {
         "code": "Code"
       },

--- a/i18n/locales/fr.json
+++ b/i18n/locales/fr.json
@@ -297,6 +297,7 @@
       "emailDescription": "Entrez votre adresse courriel pour recevoir un code par courriel.",
       "totpRegisterDescription": "Scannez le code QR ou accédez au lien URL.",
       "submit": "Continuer",
+      "alreadySetUp": "Votre application d'authentification est déjà configurée sur votre compte. Pour modifier votre méthode de vérification, supprimez la configuration existante de l'application d'authentification dans les paramètres de votre compte.",
       "labels": {
         "code": "Code"
       },

--- a/i18n/locales/fr.json
+++ b/i18n/locales/fr.json
@@ -312,7 +312,7 @@
       "emailDescription": "Entrez votre adresse courriel pour recevoir un code par courriel.",
       "totpRegisterDescription": "Scannez le code QR ou accédez au lien URL.",
       "submit": "Continuer",
-      "alreadySetUp": "Votre application d'authentification est déjà configurée sur votre compte. Pour modifier votre méthode de vérification, supprimez la configuration existante de l'application d'authentification dans les paramètres de votre compte.",
+      "alreadySetUp": "Votre application d'authentification est déjà configurée sur votre compte.",
       "labels": {
         "code": "Code"
       },

--- a/i18n/locales/fr.json
+++ b/i18n/locales/fr.json
@@ -313,6 +313,7 @@
       "totpRegisterDescription": "Scannez le code QR ou accédez au lien URL.",
       "submit": "Continuer",
       "genericError": "Nous n’avons pas pu configurer votre application d’authentification pour le moment. Veuillez réessayer.",
+      "invalidCode": "Le code est invalide. Veuillez réessayer.",
       "alreadySetUp": "Votre application d'authentification est déjà configurée sur votre compte.",
       "labels": {
         "code": "Code"

--- a/i18n/locales/fr.json
+++ b/i18n/locales/fr.json
@@ -312,6 +312,7 @@
       "emailDescription": "Entrez votre adresse courriel pour recevoir un code par courriel.",
       "totpRegisterDescription": "Scannez le code QR ou accédez au lien URL.",
       "submit": "Continuer",
+      "genericError": "Nous n’avons pas pu configurer votre application d’authentification pour le moment. Veuillez réessayer.",
       "alreadySetUp": "Votre application d'authentification est déjà configurée sur votre compte.",
       "labels": {
         "code": "Code"

--- a/lib/zitadel-errors.ts
+++ b/lib/zitadel-errors.ts
@@ -1,0 +1,53 @@
+import { ConnectError } from "@connectrpc/connect";
+import { ErrorDetailSchema } from "@zitadel/proto/zitadel/message_pb";
+
+export type ZitadelErrorContext = "otp.set";
+
+export type ZitadelUiError = {
+  namespace: string;
+  i18nKey: string;
+  blockContinue?: boolean;
+};
+
+function getFirstErrorDetail(err: ConnectError) {
+  return err.findDetails(ErrorDetailSchema)[0];
+}
+
+function getErrorDetailFields(detail: unknown): { id?: string; message?: string } {
+  if (!detail || typeof detail !== "object") {
+    return {};
+  }
+
+  const candidate = detail as { id?: string; message?: string };
+  return {
+    id: candidate.id,
+    message: candidate.message,
+  };
+}
+
+function isOtpAlreadyReadyError(err: ConnectError): boolean {
+  const detail = getErrorDetailFields(getFirstErrorDetail(err));
+  const normalizedMessage =
+    `${detail.message ?? ""} ${err.rawMessage ?? ""} ${err.message ?? ""}`.toLowerCase();
+
+  return err.code === 6 || normalizedMessage.includes("already set up");
+}
+
+export function getZitadelUiError(
+  context: ZitadelErrorContext,
+  err: unknown
+): ZitadelUiError | undefined {
+  if (!(err instanceof ConnectError)) {
+    return undefined;
+  }
+
+  if (context === "otp.set" && isOtpAlreadyReadyError(err)) {
+    return {
+      namespace: "otp",
+      i18nKey: "set.alreadySetUp",
+      blockContinue: true,
+    };
+  }
+
+  return undefined;
+}


### PR DESCRIPTION
# Summary | Résumé

We need to be able to parse errors and display friendly UI errors

fixes: https://github.com/cds-snc/platform-forms-client/issues/6794

Zitadel throws ConnectError 's 

```
import { Code, ConnectError, create } from "@zitadel/client";
```

The incoming detail has 

```
type IncomingDetail = {
    type: string;
    value: Uint8Array;
    debug?: JsonValue;
};
```
We need to be able to parse into a useable structure on our end.


Testing 

Visit 
http://localhost:3002/otp/time-based/set?checkAfter=true



Notes:

https://connectrpc.com/docs/protocol/#error-codes

```
import { Code, ConnectError, create } from "@zitadel/client";
import { ErrorDetailSchema } from "@zitadel/proto/zitadel/message_pb";

const detail = create(ErrorDetailSchema, {
  id: "OTPAlreadyReady",
  message: "Multifactor OTP already set up",
});

throw new ConnectError(
  "Multifactor OTP already set up",
  Code.InvalidArgument,
  undefined,
  [{ desc: ErrorDetailSchema, value: detail }]
);
```
