### PR TITLE
chore: remove verify step when creating fresh account

### DIFF
--- a/components/mfa/otp/TotpRegister.tsx
+++ b/components/mfa/otp/TotpRegister.tsx
@@ -67,10 +67,12 @@ export function TotpRegister({ uri, loginName, requestId, organization, checkAft
     return verifyTOTP(normalizedCode, loginName, organization)
       .then(async () => {
         if (checkAfter) {
+          // Reuse the just-entered TOTP code to verify the active session inline.
           const checks = create(ChecksSchema, {
             totp: { code: normalizedCode },
           });
 
+          // Mark second-factor checks complete for this session during setup.
           const sessionResponse = await updateSession({
             loginName,
             organization,
@@ -83,7 +85,7 @@ export function TotpRegister({ uri, loginName, requestId, organization, checkAft
           }
         }
 
-        // Redirect to all-set page after successful setup
+        // Setup (and optional inline verification) succeeded; continue to all-set.
         const params = new URLSearchParams({});
         if (requestId) {
           params.append("requestId", requestId);

--- a/components/mfa/otp/TotpRegister.tsx
+++ b/components/mfa/otp/TotpRegister.tsx
@@ -6,12 +6,15 @@
 import { useActionState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
+import { create } from "@zitadel/client";
+import { ChecksSchema } from "@zitadel/proto/zitadel/session/v2/session_service_pb";
 import { QRCodeSVG } from "qrcode.react";
 
 /*--------------------------------------------*
  * Internal Aliases
  *--------------------------------------------*/
 import { getSafeErrorMessage } from "@lib/safeErrorMessage";
+import { updateSession } from "@lib/server/session";
 import { verifyTOTP } from "@lib/server/verify";
 import { validateTotpCode } from "@lib/validationSchemas";
 import { getZitadelUiError } from "@lib/zitadel-errors";
@@ -63,21 +66,29 @@ export function TotpRegister({ uri, loginName, requestId, organization, checkAft
 
     return verifyTOTP(normalizedCode, loginName, organization)
       .then(async () => {
+        if (checkAfter) {
+          const checks = create(ChecksSchema, {
+            totp: { code: normalizedCode },
+          });
+
+          const sessionResponse = await updateSession({
+            loginName,
+            organization,
+            checks,
+            requestId,
+          });
+
+          if (sessionResponse && "error" in sessionResponse && sessionResponse.error) {
+            throw sessionResponse.error;
+          }
+        }
+
         // Redirect to all-set page after successful setup
         const params = new URLSearchParams({});
         if (requestId) {
           params.append("requestId", requestId);
         }
-        if (checkAfter) {
-          params.append("checkAfter", "true");
-          params.append("method", "time-based");
-          if (loginName) {
-            params.append("loginName", loginName);
-          }
-          if (organization) {
-            params.append("organization", organization);
-          }
-        }
+
         return router.push(`/all-set?` + params);
       })
       .then(() => {

--- a/components/mfa/u2f/RegisterU2f.tsx
+++ b/components/mfa/u2f/RegisterU2f.tsx
@@ -213,6 +213,7 @@ export function RegisterU2f({ sessionId, requestId, checkAfter }: Props) {
       }
 
       if (checkAfter) {
+        // Step 1: request a WebAuthn assertion challenge for the active session.
         const challengeResponse = await updateSession({
           sessionId,
           requestId,
@@ -255,6 +256,7 @@ export function RegisterU2f({ sessionId, requestId, checkAfter }: Props) {
           );
         }
 
+        // Step 2: run navigator.credentials.get() to produce assertion data.
         const credential = await navigator.credentials
           .get({
             publicKey: publicKeyCredentialRequestOptions,
@@ -289,6 +291,7 @@ export function RegisterU2f({ sessionId, requestId, checkAfter }: Props) {
           },
         } as JsonObject;
 
+        // Step 3: submit the assertion as WebAuthN session checks.
         const verificationResponse = await updateSession({
           sessionId,
           requestId,
@@ -310,6 +313,7 @@ export function RegisterU2f({ sessionId, requestId, checkAfter }: Props) {
           return;
         }
 
+        // Session is verified inline, so continue without a separate /u2f verify hop.
         const params = new URLSearchParams({});
         if (requestId) {
           params.append("requestId", requestId);


### PR DESCRIPTION
# Summary | Résumé

Removes need for checkAfter verification for logging in.

Update auth app authentication / hardware key to register and verify (login) as chained in one step vs separate steps.