### PR TITLE
chore: fix 500 error for invalid code 

### DIFF
--- a/components/mfa/otp/TotpRegister.tsx
+++ b/components/mfa/otp/TotpRegister.tsx
@@ -65,7 +65,11 @@ export function TotpRegister({ uri, loginName, requestId, organization, checkAft
     }
 
     return verifyTOTP(normalizedCode, loginName, organization)
-      .then(async () => {
+      .then(async (verifyResponse) => {
+        if (verifyResponse && "error" in verifyResponse && verifyResponse.error) {
+          throw verifyResponse.error;
+        }
+
         if (checkAfter) {
           // Reuse the just-entered TOTP code to verify the active session inline.
           const checks = create(ChecksSchema, {


### PR DESCRIPTION
# Summary

## Issue
Visiting and submitting on:

- `http://localhost:3002/otp/time-based/set?checkAfter=true`

was causing a 500 error tied to `verifyTOTP` in `lib/server/verify.ts`.

## Fix

- Updated `verifyTOTP(code, loginName?, organization?)` to **not throw** on session lookup/verification failures.
- It now returns:
  - `{ success: true }` on success
  - `{ error }` on failure


- Added a minimal guard in the first `.then(...)` after `verifyTOTP(...)`:
  - if `verifyResponse.error` exists, throw it into the existing `.catch(...)` branch so existing UI error mapping is used.

## Expected Behavior
- No server-action 500 from `verifyTOTP` path.
- Success still navigates to `/all-set`.
- Failures still display inline OTP error messaging.

## Quick Retest (Register Path)
1. Create a new account and continue through login until the MFA setup step.
2. Select **Auth App** as the MFA method.
3. On the register page (`/otp/time-based/set?checkAfter=true`), enter an invalid 6-digit code.
4. Confirm there is no 500 error and an inline validation/error message appears.


