### PR TITLE
chore: manually add cache directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ COPY --from=base /src/package.json ./package.json
 COPY --from=base /src/.next/standalone ./
 COPY --from=base /src/.next/static ./.next/static
 
+RUN mkdir /src/.next/cache
 
 EXPOSE 3000
 


### PR DESCRIPTION
# Summary | Résumé
Manually add the cache directory to see if the nextjs process still has issues with server optimized image caching.