### PR TITLE
chore: Do not optimize images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,6 @@ COPY --from=base /src/package.json ./package.json
 COPY --from=base /src/.next/standalone ./
 COPY --from=base /src/.next/static ./.next/static
 
-RUN mkdir /src/.next/cache
-
 EXPOSE 3000
 
 CMD ["node", "server.js"]

--- a/next.config.ts
+++ b/next.config.ts
@@ -41,6 +41,9 @@ const nextConfig: NextConfig = {
           }
         : false,
   },
+  images: {
+    unoptimized: true,
+  },
   serverExternalPackages: ["pino", "pino-pretty", "thread-stream"],
   async headers() {
     return [


### PR DESCRIPTION
# Summary | Résumé
Try this next.js config to no optimize images as they are already optimized.
Will hopefully remove cache error