### PR TITLE
chore: update code to normalize oidc request id

### DIFF
--- a/lib/oidc-request-id.test.ts
+++ b/lib/oidc-request-id.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import { toAuthRequestId, toOidcRequestId } from "./oidc-request-id";
+
+describe("oidc-request-id", () => {
+  it("returns bare auth request id for unprefixed value", () => {
+    expect(toAuthRequestId("12345")).toBe("12345");
+  });
+
+  it("strips one or multiple oidc_ prefixes for auth request id", () => {
+    expect(toAuthRequestId("oidc_12345")).toBe("12345");
+    expect(toAuthRequestId("oidc_oidc_12345")).toBe("12345");
+  });
+
+  it("returns canonical prefixed request id", () => {
+    expect(toOidcRequestId("12345")).toBe("oidc_12345");
+    expect(toOidcRequestId("oidc_12345")).toBe("oidc_12345");
+    expect(toOidcRequestId("oidc_oidc_12345")).toBe("oidc_12345");
+  });
+});

--- a/lib/oidc-request-id.ts
+++ b/lib/oidc-request-id.ts
@@ -1,0 +1,13 @@
+/**
+ * OIDC IDs come in two formats depending on context:
+ * - authRequestId: bare Zitadel auth request id (no prefix), used for API calls like createCallback/getAuthRequest
+ * - requestId: UI flow id with `oidc_` prefix, used in URLs and app routing
+ */
+
+export function toAuthRequestId(value: string): string {
+  return value.replace(/^(oidc_)+/, "");
+}
+
+export function toOidcRequestId(value: string): string {
+  return `oidc_${toAuthRequestId(value)}`;
+}

--- a/lib/oidc.ts
+++ b/lib/oidc.ts
@@ -9,6 +9,7 @@ import {
 import { Session } from "@zitadel/proto/zitadel/session/v2/session_pb";
 
 import { Cookie } from "@lib/cookies";
+import { toAuthRequestId, toOidcRequestId } from "@lib/oidc-request-id";
 import { sendLoginname, SendLoginnameCommand } from "@lib/server/loginname";
 import { createCallback } from "@lib/zitadel";
 
@@ -28,6 +29,9 @@ export async function loginWithOIDCAndSession({
   sessions,
   sessionCookies,
 }: LoginWithOIDCAndSession): Promise<{ error: string } | { redirect: string }> {
+  const authRequestId = toAuthRequestId(authRequest);
+  const oidcRequestId = toOidcRequestId(authRequest);
+
   console.log(`Login with session: ${sessionId} and authRequest: ${authRequest}`);
 
   const selectedSession = sessions.find((s) => s.id === sessionId);
@@ -49,7 +53,7 @@ export async function loginWithOIDCAndSession({
       const command: SendLoginnameCommand = {
         loginName: selectedSession.factors.user?.loginName,
         organization: selectedSession.factors?.user?.organizationId,
-        requestId: `oidc_${authRequest}`,
+        requestId: oidcRequestId,
       };
 
       const res = await sendLoginname(command);
@@ -72,7 +76,7 @@ export async function loginWithOIDCAndSession({
         const { callbackUrl } = await createCallback({
           serviceUrl,
           req: create(CreateCallbackRequestSchema, {
-            authRequestId: authRequest,
+            authRequestId,
             callbackKind: {
               case: "session",
               value: create(SessionSchema, session),

--- a/lib/server/flow-initiation.ts
+++ b/lib/server/flow-initiation.ts
@@ -14,6 +14,7 @@ import { IdentityProviderType } from "@zitadel/proto/zitadel/settings/v2/login_s
 
 import { Cookie } from "@lib/cookies";
 import { idpTypeToSlug } from "@lib/idp";
+import { toAuthRequestId, toOidcRequestId } from "@lib/oidc-request-id";
 import { sendLoginname, SendLoginnameCommand } from "@lib/server/loginname";
 import { constructUrl } from "@lib/service-url";
 import { findValidSession } from "@lib/session";
@@ -102,12 +103,16 @@ export async function handleOIDCFlowInitiation(
 ): Promise<NextResponse> {
   const { serviceUrl, requestId, sessions, sessionCookies, request } = params;
 
+  const authRequestId = toAuthRequestId(requestId);
+
   const { authRequest } = await getAuthRequest({
     serviceUrl,
-    authRequestId: requestId.replace("oidc_", ""),
+    authRequestId,
   });
 
-  const oidcRequestId = authRequest?.id ? `oidc_${authRequest.id}` : requestId;
+  const oidcRequestId = authRequest?.id
+    ? toOidcRequestId(authRequest.id)
+    : toOidcRequestId(requestId);
 
   let organization = "";
   let idpId = "";
@@ -160,7 +165,7 @@ export async function handleOIDCFlowInitiation(
         if (identityProviderType === IdentityProviderType.LDAP) {
           const ldapUrl = constructUrl(request, "/ldap");
           if (authRequest.id) {
-            ldapUrl.searchParams.set("requestId", `oidc_${authRequest.id}`);
+            ldapUrl.searchParams.set("requestId", toOidcRequestId(authRequest.id));
           }
           if (organization) {
             ldapUrl.searchParams.set("organization", organization);
@@ -172,7 +177,7 @@ export async function handleOIDCFlowInitiation(
         const provider = idpTypeToSlug(identityProviderType);
 
         const params = new URLSearchParams({
-          requestId: requestId,
+          requestId: oidcRequestId,
         });
 
         if (organization) {
@@ -203,7 +208,7 @@ export async function handleOIDCFlowInitiation(
 
   if (authRequest && authRequest.prompt.includes(Prompt.CREATE)) {
     const registerUrl = constructUrl(request, "/register");
-    registerUrl.searchParams.set("requestId", requestId);
+    registerUrl.searchParams.set("requestId", oidcRequestId);
 
     if (organization) {
       registerUrl.searchParams.set("organization", organization);
@@ -297,7 +302,7 @@ export async function handleOIDCFlowInitiation(
       const { callbackUrl } = await createCallback({
         serviceUrl,
         req: create(CreateCallbackRequestSchema, {
-          authRequestId: requestId.replace("oidc_", ""),
+          authRequestId,
           callbackKind: {
             case: "session",
             value: create(SessionSchema, session),
@@ -343,7 +348,7 @@ export async function handleOIDCFlowInitiation(
         const { callbackUrl } = await createCallback({
           serviceUrl,
           req: create(CreateCallbackRequestSchema, {
-            authRequestId: requestId.replace("oidc_", ""),
+            authRequestId,
             callbackKind: {
               case: "session",
               value: create(SessionSchema, session),
@@ -356,14 +361,14 @@ export async function handleOIDCFlowInitiation(
           console.log("could not create callback, redirect user to login");
           return gotoLogin({
             request,
-            requestId,
+            requestId: oidcRequestId,
           });
         }
       } catch (error) {
         console.error(error);
         return gotoLogin({
           request,
-          requestId,
+          requestId: oidcRequestId,
         });
       }
     }
@@ -371,7 +376,7 @@ export async function handleOIDCFlowInitiation(
     // No local sessions available - start an interactive login with request context.
     return gotoLogin({
       request,
-      requestId,
+      requestId: oidcRequestId,
     });
   }
 }


### PR DESCRIPTION
# Summary | Résumé

In this codebase, two similar IDs are used:

- `authRequestId` (bare ID, **no** `oidc_` prefix) 
- `requestId` (UI flow ID, **with** `oidc_` prefix)

When these are mixed (for example, prefixed value used where bare ID is expected flow completion can fail.

```diff
-  registerUrl.searchParams.set("requestId", requestId);
+  registerUrl.searchParams.set("requestId", oidcRequestId);
```

The OIDC flow had multiple spots manually adding/removing `oidc_` using ad-hoc string operations.

Most importantly for registration:
- The create-account redirect path and follow-up flow used IDs that were not always normalized from one canonical source.
- Callback calls expected bare `authRequestId`, but input could be derived from values that may already include `oidc_`.

## What changed

Added helpers to add or remove  `oidc_` as needed.

## Notes
- If the value is sent to Zitadel OIDC APIs (`getAuthRequest`, `createCallback`), use `toAuthRequestId(...)`.
- If the value is placed in app URLs/query params (`requestId`), use `toOidcRequestId(...)`.

## Testing
1. Start OIDC flow from RP where user does not exist.
2. Complete registration.
3. Confirm redirect goes back to RP callback URL.
4. Confirm existing-user login flow still works.