### PR TITLE
chore: Otp u2f cleanup

### DIFF
--- a/app/(auth)/components/LoginForm.tsx
+++ b/app/(auth)/components/LoginForm.tsx
@@ -68,19 +68,19 @@ export function LoginForm({ requestId }: Props) {
       };
     }
 
-    const response = await submitLoginForm({
-      username: username,
-      password: password,
-      requestId,
-    })
-      .catch(() => {
-        return {
-          error: t("validation.invalidCredentials"),
-        };
-      })
-      .finally(() => {
-        setLoading(false);
+    let response;
+    try {
+      response = await submitLoginForm({
+        username: username,
+        password: password,
+        requestId,
       });
+    } catch (e) {
+      response = {
+        error: t("validation.invalidCredentials"),
+      };
+    }
+    setLoading(false);
 
     if (response && "error" in response && response.error) {
       return {

--- a/app/(auth)/otp/[method]/actions.ts
+++ b/app/(auth)/otp/[method]/actions.ts
@@ -16,6 +16,7 @@ import { sendOtpEmail } from "@lib/server/otp";
 import { updateSession } from "@lib/server/session";
 import { validateCode, validateTotpCode } from "@lib/validationSchemas";
 import { getZitadelUiError } from "@lib/zitadel-errors";
+import { serverTranslation } from "@i18n/server";
 export type FormState = {
   error?: string;
   validationErrors?: { fieldKey: string; fieldValue: string }[];
@@ -145,10 +146,10 @@ export async function handleOTPFormSubmit(
   code: string,
   params: SubmitCodeParams & {
     loginSettings?: LoginSettings;
-    t: (key: string) => string;
   }
 ): Promise<FormState & { redirect?: string }> {
-  const { loginSettings, t, ...submitParams } = params;
+  const { t } = await serverTranslation("otp");
+  const { loginSettings, ...submitParams } = params;
   const normalizedCode = code.trim();
 
   try {

--- a/app/(auth)/otp/[method]/components/LoginOTP.tsx
+++ b/app/(auth)/otp/[method]/components/LoginOTP.tsx
@@ -14,6 +14,7 @@ import { LoginSettings } from "@zitadel/proto/zitadel/settings/v2/login_settings
  *--------------------------------------------*/
 import { getSafeErrorMessage } from "@lib/safeErrorMessage";
 import { I18n, useTranslation } from "@i18n";
+import { UserAvatar } from "@components/account/user-avatar";
 import { BackButton } from "@components/ui/button/BackButton";
 import { Button } from "@components/ui/button/Button";
 import { SubmitButtonAction } from "@components/ui/button/SubmitButton";
@@ -36,7 +37,7 @@ export function LoginOTP({
   code,
   loginSettings,
   redirect,
-  children,
+  displayName,
 }: {
   loginName?: string; // either loginName or sessionId must be provided
   sessionId?: string;
@@ -46,7 +47,7 @@ export function LoginOTP({
   code?: string;
   loginSettings?: LoginSettings;
   redirect?: string | null;
-  children?: React.ReactNode;
+  displayName?: string;
 }) {
   const {
     t,
@@ -137,7 +138,11 @@ export function LoginOTP({
 
       <ErrorSummary id="errorSummary" validationErrors={state.validationErrors} />
 
-      {children}
+      {method === "email" && (
+        <I18n i18nKey="verify.emailDescription" namespace="otp" tagName="p" className="mb-3" />
+      )}
+
+      <UserAvatar loginName={loginName} displayName={displayName} showDropdown={false} />
 
       <div className="w-full">
         <form action={formAction} noValidate>

--- a/app/(auth)/otp/[method]/components/LoginOTP.tsx
+++ b/app/(auth)/otp/[method]/components/LoginOTP.tsx
@@ -90,7 +90,6 @@ export function LoginOTP({
       method,
       loginSettings,
       redirect,
-      t,
     });
 
     // Handle redirect if present

--- a/app/(auth)/otp/[method]/components/LoginOTP.tsx
+++ b/app/(auth)/otp/[method]/components/LoginOTP.tsx
@@ -55,7 +55,6 @@ export function LoginOTP({
   const genericErrorMessage = t("set.genericError");
   const invalidCodeMessage = t("set.invalidCode");
   const invalidCodeLengthMessage = t("set.invalidCodeLength");
-  const [, setError] = useState<string>("");
   const [codeSent, setCodeSent] = useState<boolean>(false);
   const [codeLoading, setCodeLoading] = useState<boolean>(false);
   const router = useRouter();
@@ -70,18 +69,13 @@ export function LoginOTP({
       method,
     });
 
-    if (error) {
-      setError(error);
-    }
+    return !error;
   };
 
   useEffect(() => {
-    if (!initialized.current && ["email"].includes(method) && !code) {
+    if (!initialized.current && method === "email" && !code) {
       initialized.current = true;
-      requestOTPChallenge().catch((error) => {
-        setError(error);
-        return;
-      });
+      requestOTPChallenge().catch(() => false);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -110,13 +104,14 @@ export function LoginOTP({
   const resendCode = async () => {
     setCodeSent(false);
     setCodeLoading(true);
-    requestOTPChallenge()
-      .then(() => setCodeSent(true))
-      .catch((error) => {
-        setError(error);
-        return;
-      })
-      .finally(() => setCodeLoading(false));
+    try {
+      const success = await requestOTPChallenge();
+      setCodeSent(success);
+      setCodeLoading(false);
+    } catch {
+      setCodeSent(false);
+      setCodeLoading(false);
+    }
   };
 
   const [state, formAction, isPending] = useActionState(localFormAction, {
@@ -160,7 +155,7 @@ export function LoginOTP({
           <Link href={`${SUPPORT_URL}/${language}/support`}>
             <I18n i18nKey="help" namespace="verify" />
           </Link>
-          {["email"].includes(method) && (
+          {method === "email" && (
             <div className="flex whitespace-nowrap" aria-live="polite">
               <Button
                 theme="link"

--- a/app/(auth)/otp/[method]/page.tsx
+++ b/app/(auth)/otp/[method]/page.tsx
@@ -13,9 +13,7 @@ import { getServiceUrlFromHeaders } from "@lib/service-url";
 import { loadSessionById, loadSessionByLoginname } from "@lib/session";
 import { getSerializableObject, SearchParams } from "@lib/utils";
 import { getLoginSettings } from "@lib/zitadel";
-import { I18n } from "@i18n";
 import { serverTranslation } from "@i18n/server";
-import { UserAvatar } from "@components/account/user-avatar";
 import { AuthPanel } from "@components/auth/AuthPanel";
 
 /*--------------------------------------------*
@@ -75,19 +73,8 @@ export default async function Page(props: {
           loginSettings={loginSettings}
           code={code}
           redirect={safeRedirect}
-        >
-          {method === "email" && (
-            <I18n i18nKey="verify.emailDescription" namespace="otp" tagName="p" className="mb-3" />
-          )}
-
-          {sessionFactors && (
-            <UserAvatar
-              loginName={loginName ?? sessionFactors.factors?.user?.loginName}
-              displayName={sessionFactors.factors?.user?.displayName}
-              showDropdown={false}
-            />
-          )}
-        </LoginOTP>
+          displayName={sessionFactors.factors?.user?.displayName}
+        />
       )}
     </AuthPanel>
   );

--- a/app/(auth)/u2f/components/LoginU2F.tsx
+++ b/app/(auth)/u2f/components/LoginU2F.tsx
@@ -181,8 +181,6 @@ export function LoginU2F({
   }
 
   async function startU2FLoginFlow() {
-    setError("");
-
     const response = await updateSessionForChallenge();
     const publicKey = response?.challenges?.webAuthN?.publicKeyCredentialRequestOptions?.publicKey;
 

--- a/app/(auth)/u2f/components/LoginU2F.tsx
+++ b/app/(auth)/u2f/components/LoginU2F.tsx
@@ -44,6 +44,51 @@ type Props = {
   redirect?: string | null;
 };
 
+async function getCredentialAssertionData(
+  publicKey: PublicKeyCredentialRequestOptionsData
+): Promise<JsonObject | null> {
+  const normalizedPublicKey: PublicKeyCredentialRequestOptionsData = {
+    ...publicKey,
+    challenge: coerceToArrayBuffer(publicKey.challenge, "publicKey.challenge"),
+    allowCredentials: publicKey.allowCredentials?.map(
+      (listItem: PublicKeyCredentialDescriptor) => ({
+        ...listItem,
+        id: coerceToArrayBuffer(listItem.id, "publicKey.allowCredentials.id"),
+        // Only allow hardware key transports (USB, NFC, BLE) - excludes platform/internal transports
+        transports: ["usb", "ble", "nfc"] as AuthenticatorTransport[],
+      })
+    ),
+  };
+
+  const credential = (await navigator.credentials.get({
+    publicKey: normalizedPublicKey,
+  } as CredentialRequestOptions)) as Credential | null;
+
+  if (!credential) {
+    return null;
+  }
+
+  const assertedCredential = credential as PublicKeyCredential;
+  const assertionResponse = assertedCredential.response as AuthenticatorAssertionResponse;
+  const authData = new Uint8Array(assertionResponse.authenticatorData);
+  const clientDataJSON = new Uint8Array(assertionResponse.clientDataJSON);
+  const rawId = new Uint8Array(assertedCredential.rawId);
+  const sig = new Uint8Array(assertionResponse.signature);
+  const userHandle = new Uint8Array(assertionResponse.userHandle || []);
+
+  return {
+    id: assertedCredential.id,
+    rawId: coerceToBase64Url(rawId, "rawId"),
+    type: assertedCredential.type,
+    response: {
+      authenticatorData: coerceToBase64Url(authData, "authData"),
+      clientDataJSON: coerceToBase64Url(clientDataJSON, "clientDataJSON"),
+      signature: coerceToBase64Url(sig, "sig"),
+      userHandle: coerceToBase64Url(userHandle, "userHandle"),
+    },
+  } as JsonObject;
+}
+
 export function LoginU2F({
   loginName,
   sessionId,
@@ -64,28 +109,26 @@ export function LoginU2F({
       ? UserVerificationRequirement.REQUIRED
       : UserVerificationRequirement.DISCOURAGED
   ) {
-    setError("");
-    const session = await updateSession({
-      loginName,
-      sessionId,
-      organization,
-      challenges: create(RequestChallengesSchema, {
-        webAuthN: {
-          domain: "",
-          userVerificationRequirement,
-        },
-      }),
-      requestId,
-    }).catch(() => {
-      console.error("Error requesting challenge - likely network or server error");
+    let session;
+    try {
+      session = await updateSession({
+        loginName,
+        sessionId,
+        organization,
+        challenges: create(RequestChallengesSchema, {
+          webAuthN: {
+            domain: "",
+            userVerificationRequirement,
+          },
+        }),
+        requestId,
+      });
+    } catch {
       setError(t("verify.errors.couldNotRequestChallenge"));
       return;
-    });
+    }
 
     if (session && "error" in session && session.error) {
-      console.error(
-        "Error in response when requesting challenge - likely validation or other server error"
-      );
       setError(
         typeof session.error === "string"
           ? session.error
@@ -103,19 +146,22 @@ export function LoginU2F({
   }
 
   async function submitLogin(data: JsonObject) {
-    const response = await verifyU2FLogin({
-      loginName,
-      sessionId,
-      organization,
-      checks: {
-        webAuthN: { credentialAssertionData: data },
-      } as Checks,
-      requestId,
-      redirect,
-    }).catch(() => {
+    let response;
+    try {
+      response = await verifyU2FLogin({
+        loginName,
+        sessionId,
+        organization,
+        checks: {
+          webAuthN: { credentialAssertionData: data },
+        } as Checks,
+        requestId,
+        redirect,
+      });
+    } catch {
       setError(t("verify.errors.couldNotVerifyPasskey"));
       return;
-    });
+    }
 
     if (response && "error" in response && response.error) {
       setError(response.error);
@@ -134,82 +180,41 @@ export function LoginU2F({
     }
   }
 
-  async function submitLoginAndContinue(
-    publicKey: PublicKeyCredentialRequestOptionsData
-  ): Promise<boolean | void> {
-    publicKey.challenge = coerceToArrayBuffer(publicKey.challenge, "publicKey.challenge");
-    if (publicKey.allowCredentials) {
-      publicKey.allowCredentials.map((listItem: PublicKeyCredentialDescriptor) => {
-        listItem.id = coerceToArrayBuffer(listItem.id, "publicKey.allowCredentials.id");
-        // Only allow hardware key transports (USB, NFC, BLE) - excludes platform/internal transports
-        listItem.transports = ["usb", "ble", "nfc"] as AuthenticatorTransport[];
-      });
+  async function startU2FLoginFlow() {
+    setError("");
+
+    const response = await updateSessionForChallenge();
+    const publicKey = response?.challenges?.webAuthN?.publicKeyCredentialRequestOptions?.publicKey;
+
+    if (!publicKey) {
+      setError(t("verify.errors.couldNotRequestChallenge"));
+      return;
     }
 
-    return navigator.credentials
-      .get({
-        publicKey,
-      } as CredentialRequestOptions)
-      .then((credential: Credential | null) => {
-        if (!credential) {
-          setError(t("verify.errors.couldNotRetrievePasskey"));
-          return;
-        }
+    try {
+      const data = await getCredentialAssertionData(
+        publicKey as PublicKeyCredentialRequestOptionsData
+      );
 
-        const assertedCredential = credential as PublicKeyCredential;
-        const assertionResponse = assertedCredential.response as AuthenticatorAssertionResponse;
-        const authData = new Uint8Array(assertionResponse.authenticatorData);
-        const clientDataJSON = new Uint8Array(assertionResponse.clientDataJSON);
-        const rawId = new Uint8Array(assertedCredential.rawId);
-        const sig = new Uint8Array(assertionResponse.signature);
-        const userHandle = new Uint8Array(assertionResponse.userHandle || []);
-        const data = {
-          id: assertedCredential.id,
-          rawId: coerceToBase64Url(rawId, "rawId"),
-          type: assertedCredential.type,
-          response: {
-            authenticatorData: coerceToBase64Url(authData, "authData"),
-            clientDataJSON: coerceToBase64Url(clientDataJSON, "clientDataJSON"),
-            signature: coerceToBase64Url(sig, "sig"),
-            userHandle: coerceToBase64Url(userHandle, "userHandle"),
-          },
-        };
+      if (!data) {
+        setError(t("verify.errors.couldNotRetrievePasskey"));
+        return;
+      }
 
-        return submitLogin(data);
-      })
-      .catch((error: Error) => {
-        // Handle U2F verification cancellation or errors
-        if (error?.name === "NotAllowedError") {
-          setError(t("verify.errors.verificationCancelled"));
-        } else {
-          setError(t("verify.errors.verificationFailed"));
-        }
-      });
+      await submitLogin(data);
+    } catch (error) {
+      if ((error as Error)?.name === "NotAllowedError") {
+        setError(t("verify.errors.verificationCancelled"));
+      } else {
+        setError(t("verify.errors.verificationFailed"));
+      }
+    }
   }
 
   useEffect(() => {
     if (!initialized.current) {
       initialized.current = true;
-      updateSessionForChallenge()
-        .then((response) => {
-          const pK = response?.challenges?.webAuthN?.publicKeyCredentialRequestOptions?.publicKey;
-
-          if (!pK) {
-            setError(t("verify.errors.couldNotRequestChallenge"));
-            return;
-          }
-
-          return submitLoginAndContinue(pK as PublicKeyCredentialRequestOptionsData).catch(
-            (error) => {
-              setError(error);
-              return;
-            }
-          );
-        })
-        .catch((error) => {
-          setError(error);
-          return;
-        });
+      void startU2FLoginFlow();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/app/(auth)/u2f/components/LoginU2F.tsx
+++ b/app/(auth)/u2f/components/LoginU2F.tsx
@@ -152,9 +152,7 @@ export function LoginU2F({
         loginName,
         sessionId,
         organization,
-        checks: {
-          webAuthN: { credentialAssertionData: data },
-        } as Checks,
+        checks: { webAuthN: { credentialAssertionData: data } } as Checks,
         requestId,
         redirect,
       });

--- a/app/(auth)/u2f/set/components/RegisterU2f.tsx
+++ b/app/(auth)/u2f/set/components/RegisterU2f.tsx
@@ -69,19 +69,20 @@ export function RegisterU2f({ sessionId, requestId, checkAfter }: Props) {
     setError("");
     setLoading(true);
 
-    const response = await verifyU2F({
-      u2fId,
-      passkeyName,
-      publicKeyCredential,
-      sessionId,
-    })
-      .catch(() => {
-        setError("set.errors.verificationFailed");
-        return;
-      })
-      .finally(() => {
-        setLoading(false);
+    let response;
+    try {
+      response = await verifyU2F({
+        u2fId,
+        passkeyName,
+        publicKeyCredential,
+        sessionId,
       });
+    } catch (e) {
+      setError("set.errors.verificationFailed");
+      setLoading(false);
+      return;
+    }
+    setLoading(false);
 
     if (response && "error" in response && response?.error) {
       setError(response?.error);
@@ -95,16 +96,17 @@ export function RegisterU2f({ sessionId, requestId, checkAfter }: Props) {
     setError("");
     setLoading(true);
 
-    const response = await addU2F({
-      sessionId,
-    })
-      .catch(() => {
-        setError("set.errors.credentialRegistrationFailed");
-        return;
-      })
-      .finally(() => {
-        setLoading(false);
+    let response;
+    try {
+      response = await addU2F({
+        sessionId,
       });
+    } catch (e) {
+      setError("set.errors.credentialRegistrationFailed");
+      setLoading(false);
+      return;
+    }
+    setLoading(false);
 
     if (response && "error" in response && response?.error) {
       setError(response?.error);

--- a/app/(auth)/verify/components/VerifyEmailForm.tsx
+++ b/app/(auth)/verify/components/VerifyEmailForm.tsx
@@ -75,9 +75,8 @@ export function VerifyEmailForm({
       }
     } catch {
       setError(t("errors.couldNotResendEmail"));
-    } finally {
-      setCodeLoading(false);
     }
+    setCodeLoading(false);
   }
 
   // Send verification email once on component mount

--- a/components/auth/LogoutButton.tsx
+++ b/components/auth/LogoutButton.tsx
@@ -39,9 +39,8 @@ export function LogoutButton({ className, label, postLogoutRedirectUri }: Logout
     } catch {
       // Fallback to logout page
       router.push("/logout");
-    } finally {
-      setIsLoggingOut(false);
     }
+    setIsLoggingOut(false);
   }
 
   return (


### PR DESCRIPTION
# Summary | Résumé

- Moves some logic out of the use effect and into functions the component can use.
- Fixes Email OTP issue with server translation 
- Fixed the OTP flow by stopping server-rendered children and rendering the same UI from stable client props instead, which prevents the post-submit edit “children changed” React error.

This was happening when entering an invalid code and than editing or adding a new code

> Console Error

The children should not have changed if we pass in the same set.
Call Stack
50

