### PR TITLE
fix: personal details form retaining old state

### DIFF
--- a/app/account/components/PersonalDetails.tsx
+++ b/app/account/components/PersonalDetails.tsx
@@ -53,7 +53,7 @@ export const PersonalDetails = ({
     }
   }, [editMode]);
 
-  const localFormAction = async (previousState: FormState, formData: FormData) => {
+  const localFormAction = async (_: FormState, formData: FormData) => {
     const formEntries = {
       firstname: (formData.get("firstname") as string) || "",
       lastname: (formData.get("lastname") as string) || "",
@@ -84,10 +84,11 @@ export const PersonalDetails = ({
       };
     }
 
-    setEditMode(false);
     toast.success(t("personalDetails.success.updateSuccess"), "account-details");
-
-    return previousState;
+    setEditMode(false);
+    return {
+      formData: formEntries,
+    };
   };
 
   const [state, formAction] = useActionState(localFormAction, {


### PR DESCRIPTION
# Summary | Résumé

Update the personal details form to return the updated form state when a user changes their name.