### PR TITLE
chore: re-add user id and org for verify

### DIFF
--- a/lib/verify-helper.test.ts
+++ b/lib/verify-helper.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { checkEmailVerification } from "./verify-helper";
+
+describe("checkEmailVerification", () => {
+  const originalEmailVerification = process.env.EMAIL_VERIFICATION;
+
+  afterEach(() => {
+    process.env.EMAIL_VERIFICATION = originalEmailVerification;
+  });
+
+  it("preserves user and organization context for verify redirects", () => {
+    process.env.EMAIL_VERIFICATION = "true";
+
+    const redirect = checkEmailVerification(
+      {
+        factors: {
+          user: {
+            id: "user-123",
+            loginName: "person@canada.ca",
+            organizationId: "org-1",
+          },
+        },
+      } as never,
+      {
+        email: {
+          isVerified: false,
+        },
+      } as never,
+      "org-1",
+      "oidc_req-123"
+    );
+
+    expect(redirect).toEqual({
+      redirect: "/verify?requestId=oidc_req-123&userId=user-123&send=true&organization=org-1",
+    });
+  });
+});

--- a/lib/verify-helper.ts
+++ b/lib/verify-helper.ts
@@ -78,8 +78,13 @@ export function checkEmailVerification(
 ) {
   if (!humanUser?.email?.isVerified && process.env.EMAIL_VERIFICATION === "true") {
     const params = new URLSearchParams({
+      userId: session.factors?.user?.id as string,
       send: "true", // set this to true as we dont expect old email codes to be valid anymore
     });
+
+    if (organization || session.factors?.user?.organizationId) {
+      params.set("organization", organization ?? (session.factors?.user?.organizationId as string));
+    }
 
     const verifyUrl = buildUrlWithRequestId("/verify", requestId);
     const [basePath, existingQuery = ""] = verifyUrl.split("?");


### PR DESCRIPTION
# Summary | Résumé

Updates the verify path to ensure we retain user id and organization.

Fixes the oidc flow when registering a new account. 