### PR TITLE
chore: fix oidc already handled error

### DIFF
--- a/lib/oidc.ts
+++ b/lib/oidc.ts
@@ -11,7 +11,7 @@ import { Session } from "@zitadel/proto/zitadel/session/v2/session_pb";
 import { Cookie } from "@lib/cookies";
 import { toAuthRequestId, toOidcRequestId } from "@lib/oidc-request-id";
 import { sendLoginname, SendLoginnameCommand } from "@lib/server/loginname";
-import { createCallback } from "@lib/zitadel";
+import { createCallback, getAuthRequest, getLoginSettings } from "@lib/zitadel";
 
 import { isSessionValid } from "./session";
 
@@ -93,8 +93,32 @@ export async function loginWithOIDCAndSession({
         // handle already handled gracefully as these could come up if old emails with requestId are used (reset password, register emails etc.)
         console.error(error);
         if (error && typeof error === "object" && "code" in error && error?.code === 9) {
-          // Auth request already handled - signal this so the caller can redirect to login for a fresh flow
-          return { error: "Auth request already handled" };
+          // Already-handled auth requests can happen due to retries or duplicate RSC renders.
+          // In that case, recover with a deterministic redirect to the relying party when possible.
+          try {
+            const { authRequest: authRequestData } = await getAuthRequest({
+              serviceUrl,
+              authRequestId,
+            });
+
+            if (authRequestData?.redirectUri) {
+              return { redirect: authRequestData.redirectUri };
+            }
+          } catch (_authRequestError) {
+            // Fall through to login settings fallback when auth request lookup fails.
+          }
+
+          const loginSettings = await getLoginSettings({
+            serviceUrl,
+            organization: selectedSession.factors?.user?.organizationId,
+          });
+
+          if (loginSettings?.defaultRedirectUri) {
+            return { redirect: loginSettings.defaultRedirectUri };
+          }
+
+          // Final fallback keeps the user in a signed-in state within the portal.
+          return { redirect: "/account" };
         } else {
           return { error: "Unknown error occurred" };
         }

--- a/lib/server/auth-flow.ts
+++ b/lib/server/auth-flow.ts
@@ -56,12 +56,6 @@ export async function completeAuthFlow(
       return { error: "Authentication completed but navigation failed" };
     }
 
-    // Handle "already handled" error - redirect to login route to trigger fresh flow
-    // This happens when the auth request was consumed during registration
-    if ("error" in result && result.error === "Auth request already handled") {
-      return { redirect: `/login?requestId=${requestId}` };
-    }
-
     return result;
   } else if (requestId.startsWith("saml_")) {
     // Complete SAML flow


### PR DESCRIPTION
# Summary | Résumé

Short summary:

The same OIDC request was being completed twice.
First completion succeeds, second one returns already handled.
Old behavior then sent users back to login with the same consumed requestId, which caused 400.

Example:

First call: /ui/v2/login?requestId=oidc_123 -> callback to forms-staging works
Second call with same requestId: oidc_123 already handled
Old fallback: /login?requestId=oidc_123 -> 400 loop
New fallback: go to requesting site redirect (or /account if unavailable) instead of replaying login with consumed requestId


<img width="1331" height="416" alt="Screenshot 2026-03-09 at 12 21 33 PM" src="https://github.com/user-attachments/assets/c931659c-1548-4798-8ad9-030c50b203eb" />
