### PR TITLE
feat: add devcontainer and standardize versions

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,25 @@
+{
+	"name": "platform-unified-accounts-user-portal",
+	"image": "mcr.microsoft.com/devcontainers/base:bullseye@sha256:fb17cc95abb5489d81d129c8e5f58c7c1985d009397f2718a7d1d4c26f94b302",
+	"containerEnv": {
+		"SHELL": "/bin/zsh"
+	},
+	"features": {
+		"ghcr.io/devcontainers/features/node:1": {
+			"version": "24.14.1",
+			"pnpmVersion": "10.33.0"
+		}
+	},
+
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"github.copilot",
+				"github.vscode-github-actions"
+			]
+		}
+	},
+
+	"remoteUser": "vscode",
+	"postCreateCommand": "pnpm install"
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,12 +21,12 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: 10
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /.pnp
 .pnp.*
 .yarn/*
+.pnpm-store
 !.yarn/patches
 !.yarn/plugins
 !.yarn/releases

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,3 +4,6 @@ ignoredBuiltDependencies:
   - '@parcel/watcher'
   - sharp
   - unrs-resolver
+
+blockExoticSubdeps: true
+minimumReleaseAge: 10080 # 7 days


### PR DESCRIPTION
# Summary
Add a devcontainer that creates a local development environment.

Additionally this standardizes the Node and pnpm versions used in the project and adds pnpm settings to help [mitigate supply chain attacks](https://pnpm.io/supply-chain-security):

- [blockExoticSubdeps](https://pnpm.io/settings#blockexoticsubdeps): prevent transitive dependencies from using exotic sources like git repositories or direct tarball URLs.
- [minimumReleaseAge](https://pnpm.io/settings#minimumreleaseage) defines the minimum number of minutes that must pass after a version is published before pnpm will install it. This is needed as Renovate's `minimumReleaseAge` is no longer considered for lock file maintenance PRs.

