### PR TITLE
fix: add check for required env vars in /healthy

### DIFF
--- a/app/(api)/healthy/route.test.ts
+++ b/app/(api)/healthy/route.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+describe("GET /healthy", () => {
+  const requiredEnvVars = [
+    "NOTIFY_API_KEY",
+    "TEMPLATE_ID",
+    "ZITADEL_API_URL",
+    "ZITADEL_ORGANIZATION",
+    "ZITADEL_SERVICE_USER_TOKEN",
+  ];
+  const originalEnv: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const key of requiredEnvVars) {
+      originalEnv[key] = process.env[key];
+      process.env[key] = "test-value";
+    }
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    for (const key of requiredEnvVars) {
+      process.env[key] = originalEnv[key];
+    }
+  });
+
+  test("returns 200 when all required env vars are set", async () => {
+    const { GET } = await import("./route");
+
+    const response = await GET();
+    expect(response.status).toBe(200);
+  });
+
+  test("returns 503 when a required env var is missing", async () => {
+    delete process.env.ZITADEL_ORGANIZATION;
+    const { GET } = await import("./route");
+
+    const response = await GET();
+    expect(response.status).toBe(503);
+  });
+
+  test("returns 503 when a required env var is empty", async () => {
+    process.env.NOTIFY_API_KEY = "";
+    const { GET } = await import("./route");
+
+    const response = await GET();
+    expect(response.status).toBe(503);
+  });
+
+  test("returns 503 when multiple required env vars are missing", async () => {
+    delete process.env.ZITADEL_API_URL;
+    delete process.env.ZITADEL_SERVICE_USER_TOKEN;
+    const { GET } = await import("./route");
+
+    const response = await GET();
+    expect(response.status).toBe(503);
+  });
+});

--- a/app/(api)/healthy/route.ts
+++ b/app/(api)/healthy/route.ts
@@ -3,5 +3,18 @@
  *--------------------------------------------*/
 import { NextResponse } from "next/server";
 export async function GET() {
-  return NextResponse.json({}, { status: 200 });
+  const requiredEnvVars = [
+    "NOTIFY_API_KEY",
+    "TEMPLATE_ID",
+    "ZITADEL_API_URL",
+    "ZITADEL_ORGANIZATION",
+    "ZITADEL_SERVICE_USER_TOKEN",
+  ];
+  const missing = requiredEnvVars.filter((key) => !process.env[key]);
+
+  if (missing.length > 0) {
+    return NextResponse.json({ error: "Missing required environment variables" }, { status: 503 });
+  }
+
+  return NextResponse.json({ status: "ok" }, { status: 200 });
 }

--- a/app/(api)/version/route.ts
+++ b/app/(api)/version/route.ts
@@ -1,3 +1,5 @@
+import { NextResponse } from "next/server";
+
 export const dynamic = "force-static";
 
 // Prefer GIT_SHA if it is available and fallback to the build timestamp
@@ -5,7 +7,8 @@ export const dynamic = "force-static";
 const VERSION = process.env.GIT_SHA ?? new Date().toISOString();
 
 export function GET() {
-  return new Response(VERSION, {
+  return new NextResponse(VERSION, {
+    status: 200,
     headers: { "content-type": "text/plain" },
   });
 }


### PR DESCRIPTION
# Summary
Add logic in the `/healthy` endpoint to make sure all required env vars have values.

Also updates the `/version` endpoint to use NextResponse for consistency.

# Related
- https://github.com/cds-snc/platform-unified-accounts-user-portal/issues/265