### PR TITLE
fix: update proxy to return Content Security Policy headers

### DIFF
--- a/lib/cspScripts.test.ts
+++ b/lib/cspScripts.test.ts
@@ -1,0 +1,116 @@
+/*--------------------------------------------*
+ * Framework and Third-Party
+ *--------------------------------------------*/
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+/*--------------------------------------------*
+ * Internal Aliases
+ *--------------------------------------------*/
+import { generateCSP } from "./cspScripts";
+
+describe("generateCSP", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("returns a unique nonce on each call", () => {
+    const first = generateCSP();
+    const second = generateCSP();
+
+    expect(first.nonce).not.toBe(second.nonce);
+  });
+
+  it("produces a single-line normalized CSP string", () => {
+    const { csp } = generateCSP();
+
+    expect(csp).not.toMatch(/\s{2,}/);
+  });
+
+  describe("production mode (NODE_ENV !== 'development')", () => {
+    it("includes nonce in script-src", () => {
+      vi.stubEnv("NODE_ENV", "production");
+      const { csp, nonce } = generateCSP();
+
+      expect(csp).toContain(`'nonce-${nonce}'`);
+      expect(csp).toContain("script-src");
+    });
+
+    it("includes nonce in style-src", () => {
+      vi.stubEnv("NODE_ENV", "production");
+      const { csp, nonce } = generateCSP();
+      const styleSrcMatch = csp.match(/style-src([^;]+);/);
+
+      expect(styleSrcMatch?.[1]).toContain(`nonce-${nonce}`);
+    });
+
+    it("does not include unsafe-inline in style-src", () => {
+      vi.stubEnv("NODE_ENV", "production");
+      const { csp } = generateCSP();
+
+      expect(csp).not.toContain("'unsafe-inline'");
+    });
+
+    it("includes upgrade-insecure-requests", () => {
+      vi.stubEnv("NODE_ENV", "production");
+      const { csp } = generateCSP();
+
+      expect(csp).toContain("upgrade-insecure-requests");
+    });
+
+    it("does not include unsafe-eval in script-src", () => {
+      vi.stubEnv("NODE_ENV", "production");
+      const { csp } = generateCSP();
+
+      expect(csp).not.toContain("'unsafe-eval'");
+    });
+
+    it("includes wasm-unsafe-eval and strict-dynamic", () => {
+      vi.stubEnv("NODE_ENV", "production");
+      const { csp } = generateCSP();
+
+      expect(csp).toContain("'wasm-unsafe-eval'");
+      expect(csp).toContain("'strict-dynamic'");
+    });
+  });
+
+  describe("development mode (NODE_ENV === 'development')", () => {
+    it("includes nonce in script-src", () => {
+      vi.stubEnv("NODE_ENV", "development");
+      const { csp, nonce } = generateCSP();
+
+      expect(csp).toContain(`'nonce-${nonce}'`);
+      expect(csp).toContain("script-src");
+    });
+
+    it("uses unsafe-inline in style-src instead of nonce", () => {
+      vi.stubEnv("NODE_ENV", "development");
+      const { csp, nonce } = generateCSP();
+      const styleSrcMatch = csp.match(/style-src([^;]+);/);
+
+      expect(styleSrcMatch?.[1]).toContain("'unsafe-inline'");
+      expect(styleSrcMatch?.[1]).not.toContain(`nonce-${nonce}`);
+    });
+
+    it("includes unsafe-eval in script-src for React dev tools", () => {
+      vi.stubEnv("NODE_ENV", "development");
+      const { csp } = generateCSP();
+
+      expect(csp).toContain("'unsafe-eval'");
+    });
+
+    it("does not include upgrade-insecure-requests to preserve localhost HTTP", () => {
+      vi.stubEnv("NODE_ENV", "development");
+      const { csp } = generateCSP();
+
+      expect(csp).not.toContain("upgrade-insecure-requests");
+    });
+
+    it("includes wasm-unsafe-eval and strict-dynamic", () => {
+      vi.stubEnv("NODE_ENV", "development");
+      const { csp } = generateCSP();
+
+      expect(csp).toContain("'wasm-unsafe-eval'");
+      expect(csp).toContain("'strict-dynamic'");
+    });
+  });
+});

--- a/lib/cspScripts.test.ts
+++ b/lib/cspScripts.test.ts
@@ -1,12 +1,13 @@
 /*--------------------------------------------*
  * Framework and Third-Party
  *--------------------------------------------*/
+import { NextResponse } from "next/server";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 /*--------------------------------------------*
  * Internal Aliases
  *--------------------------------------------*/
-import { generateCSP } from "./cspScripts";
+import { generateCSP, responseWithCSP } from "./cspScripts";
 
 describe("generateCSP", () => {
   afterEach(() => {
@@ -20,27 +21,19 @@ describe("generateCSP", () => {
     expect(first.nonce).not.toBe(second.nonce);
   });
 
-  it("produces a single-line normalized CSP string", () => {
-    const { csp } = generateCSP();
-
-    expect(csp).not.toMatch(/\s{2,}/);
-  });
-
   describe("production mode (NODE_ENV !== 'development')", () => {
     it("includes nonce in script-src", () => {
       vi.stubEnv("NODE_ENV", "production");
       const { csp, nonce } = generateCSP();
 
-      expect(csp).toContain(`'nonce-${nonce}'`);
-      expect(csp).toContain("script-src");
+      expect(csp).toContain(`script-src 'self' 'nonce-${nonce}' 'strict-dynamic';`);
     });
 
     it("includes nonce in style-src", () => {
       vi.stubEnv("NODE_ENV", "production");
       const { csp, nonce } = generateCSP();
-      const styleSrcMatch = csp.match(/style-src([^;]+);/);
 
-      expect(styleSrcMatch?.[1]).toContain(`nonce-${nonce}`);
+      expect(csp).toContain(`style-src 'self' 'nonce-${nonce}';`);
     });
 
     it("does not include unsafe-inline in style-src", () => {
@@ -64,11 +57,10 @@ describe("generateCSP", () => {
       expect(csp).not.toContain("'unsafe-eval'");
     });
 
-    it("includes wasm-unsafe-eval and strict-dynamic", () => {
+    it("includes strict-dynamic", () => {
       vi.stubEnv("NODE_ENV", "production");
       const { csp } = generateCSP();
 
-      expect(csp).toContain("'wasm-unsafe-eval'");
       expect(csp).toContain("'strict-dynamic'");
     });
   });
@@ -78,17 +70,14 @@ describe("generateCSP", () => {
       vi.stubEnv("NODE_ENV", "development");
       const { csp, nonce } = generateCSP();
 
-      expect(csp).toContain(`'nonce-${nonce}'`);
-      expect(csp).toContain("script-src");
+      expect(csp).toContain(`script-src 'self' 'nonce-${nonce}' 'unsafe-eval' 'strict-dynamic';`);
     });
 
     it("uses unsafe-inline in style-src instead of nonce", () => {
       vi.stubEnv("NODE_ENV", "development");
-      const { csp, nonce } = generateCSP();
-      const styleSrcMatch = csp.match(/style-src([^;]+);/);
+      const { csp } = generateCSP();
 
-      expect(styleSrcMatch?.[1]).toContain("'unsafe-inline'");
-      expect(styleSrcMatch?.[1]).not.toContain(`nonce-${nonce}`);
+      expect(csp).toContain(`style-src 'self' 'unsafe-inline';`);
     });
 
     it("includes unsafe-eval in script-src for React dev tools", () => {
@@ -105,12 +94,41 @@ describe("generateCSP", () => {
       expect(csp).not.toContain("upgrade-insecure-requests");
     });
 
-    it("includes wasm-unsafe-eval and strict-dynamic", () => {
+    it("includes unsafe-eval and strict-dynamic", () => {
       vi.stubEnv("NODE_ENV", "development");
       const { csp } = generateCSP();
 
-      expect(csp).toContain("'wasm-unsafe-eval'");
+      expect(csp).toContain("'unsafe-eval'");
       expect(csp).toContain("'strict-dynamic'");
     });
+  });
+});
+
+describe("responseWithCSP", () => {
+  it("sets the Content-Security-Policy header on the response", () => {
+    const response = new NextResponse();
+    const csp = "default-src 'self';";
+
+    responseWithCSP(response, csp);
+
+    expect(response.headers.get("Content-Security-Policy")).toBe(csp);
+  });
+
+  it("returns the same response object", () => {
+    const response = new NextResponse();
+
+    const result = responseWithCSP(response, "default-src 'self';");
+
+    expect(result).toBe(response);
+  });
+
+  it("overwrites an existing Content-Security-Policy header", () => {
+    const response = new NextResponse(null, {
+      headers: { "Content-Security-Policy": "default-src 'none';" },
+    });
+
+    responseWithCSP(response, "default-src 'self';");
+
+    expect(response.headers.get("Content-Security-Policy")).toBe("default-src 'self';");
   });
 });

--- a/lib/cspScripts.ts
+++ b/lib/cspScripts.ts
@@ -4,20 +4,29 @@
 import { randomUUID } from "crypto";
 /**
  * Generates a Content Security Policy header with a nonce for inline scripts and styles.
- * This prevents XSS attacks by requiring all inline scripts/styles to have a matching nonce.
  *
+ * In production, Next.js automatically attaches the nonce to its own inline styles.
+ * In development, React devtools and HMR inject styles without nonces, so
+ * 'unsafe-inline' is used instead.
+ *
+ * @see https://nextjs.org/docs/app/guides/content-security-policy
  * @returns Object containing CSP header string and base64-encoded nonce
  */
 export const generateCSP = (): { csp: string; nonce: string } => {
   // Generate a random nonce and base64 encode it
   const nonce = Buffer.from(randomUUID()).toString("base64");
 
-  // Construct CSP header with nonce
-  // script-src 'strict-dynamic' enables the browser to ignore unsafe-inline for scripts with nonce
+  // 'unsafe-eval' is required in development for React's enhanced error overlays
+  const isDev = process.env.NODE_ENV === "development";
+  const scriptSrc = isDev
+    ? `'self' 'nonce-${nonce}' 'unsafe-eval' 'wasm-unsafe-eval' 'strict-dynamic'`
+    : `'self' 'nonce-${nonce}' 'wasm-unsafe-eval' 'strict-dynamic'`;
+  const styleSrc = isDev ? `'self' 'unsafe-inline'` : `'self' 'nonce-${nonce}'`;
+
   const cspHeader = `
     default-src 'self';
-    script-src 'self' 'nonce-${nonce}' 'wasm-unsafe-eval' 'strict-dynamic';
-    style-src 'self' 'nonce-${nonce}';
+    script-src ${scriptSrc};
+    style-src ${styleSrc};
     img-src 'self' blob: data:;
     font-src 'self';
     object-src 'none';
@@ -25,8 +34,7 @@ export const generateCSP = (): { csp: string; nonce: string } => {
     form-action 'self';
     frame-ancestors 'none';
     connect-src 'self';
-    block-all-mixed-content;
-    upgrade-insecure-requests;
+    ${isDev ? "" : "upgrade-insecure-requests;"}
   `;
 
   // Normalize whitespace and return

--- a/lib/cspScripts.ts
+++ b/lib/cspScripts.ts
@@ -1,6 +1,7 @@
 /*--------------------------------------------*
  * Framework and Third-Party
  *--------------------------------------------*/
+import { NextResponse } from "next/server";
 import { randomUUID } from "crypto";
 /**
  * Generates a Content Security Policy header with a nonce for inline scripts and styles.
@@ -19,8 +20,8 @@ export const generateCSP = (): { csp: string; nonce: string } => {
   // 'unsafe-eval' is required in development for React's enhanced error overlays
   const isDev = process.env.NODE_ENV === "development";
   const scriptSrc = isDev
-    ? `'self' 'nonce-${nonce}' 'unsafe-eval' 'wasm-unsafe-eval' 'strict-dynamic'`
-    : `'self' 'nonce-${nonce}' 'wasm-unsafe-eval' 'strict-dynamic'`;
+    ? `'self' 'nonce-${nonce}' 'unsafe-eval' 'strict-dynamic'`
+    : `'self' 'nonce-${nonce}' 'strict-dynamic'`;
   const styleSrc = isDev ? `'self' 'unsafe-inline'` : `'self' 'nonce-${nonce}'`;
 
   const cspHeader = `
@@ -43,3 +44,8 @@ export const generateCSP = (): { csp: string; nonce: string } => {
     nonce,
   };
 };
+
+export function responseWithCSP(response: NextResponse, csp: string): NextResponse {
+  response.headers.set("Content-Security-Policy", csp);
+  return response;
+}

--- a/proxy.test.ts
+++ b/proxy.test.ts
@@ -1,0 +1,249 @@
+/*--------------------------------------------*
+ * Framework and Third-Party
+ *--------------------------------------------*/
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/*--------------------------------------------*
+ * Internal Aliases
+ *--------------------------------------------*/
+import { generateCSP } from "@lib/cspScripts";
+
+/*--------------------------------------------*
+ * Local Relative
+ *--------------------------------------------*/
+import { checkAuthenticationLevel, getSmartRedirect } from "./lib/server/route-protection";
+import { getServiceUrlFromHeaders } from "./lib/service-url";
+import { proxy } from "./proxy";
+
+vi.mock("@lib/cspScripts", () => ({
+  generateCSP: vi.fn(() => ({ csp: "default-src 'self';", nonce: "test-nonce" })),
+}));
+
+vi.mock("@lib/logger", () => ({
+  logMessage: {
+    error: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+vi.mock("@root/constants/config", () => ({
+  ZITADEL_ORGANIZATION: "test-org",
+}));
+
+vi.mock("./lib/server/route-protection", () => ({
+  AuthLevel: {
+    OPEN: "open",
+    BASIC_SESSION: "basic_session",
+    PASSWORD_REQUIRED: "password_required",
+    ANY_MFA_REQUIRED: "any_mfa_required",
+    STRONG_MFA_REQUIRED: "strong_mfa_required",
+  },
+  checkAuthenticationLevel: vi.fn(),
+  getSmartRedirect: vi.fn(),
+}));
+
+vi.mock("./lib/service-url", () => ({
+  getServiceUrlFromHeaders: vi.fn(() => ({ serviceUrl: "https://idp.example.com" })),
+}));
+
+vi.mock("./lib/middleware-config", () => ({
+  API_ROUTES: ["/api", "/healthy", "/security", "/login", "/logout-session"],
+  AUTH_FLOW_ROUTES: [
+    "/password",
+    "/password/reset",
+    "/mfa",
+    "/mfa/set",
+    "/otp/time-based",
+    "/otp/email",
+    "/u2f",
+    "/verify",
+  ],
+  getRequiredAuthLevel: vi.fn((pathname: string) => {
+    if (pathname === "/" || pathname.startsWith("/login") || pathname.startsWith("/register")) {
+      return "open";
+    }
+    if (pathname.startsWith("/account")) {
+      return "any_mfa_required";
+    }
+    return "password_required";
+  }),
+  matchesPattern: vi.fn((pathname: string, patterns: string[]) =>
+    patterns.some((p) => pathname === p || pathname.startsWith(p + "/"))
+  ),
+}));
+
+function makeRequest(pathname: string, headers: Record<string, string> = {}): NextRequest {
+  const url = `http://localhost:3000${pathname}`;
+  return new NextRequest(url, {
+    headers: { host: "localhost:3000", ...headers },
+  });
+}
+
+describe("proxy middleware", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(generateCSP).mockReturnValue({ csp: "default-src 'self';", nonce: "test-nonce" });
+    delete process.env.ZITADEL_API_URL;
+    delete process.env.ZITADEL_SERVICE_USER_TOKEN;
+  });
+
+  describe("Content-Security-Policy headers", () => {
+    it("sets CSP header on open route responses", async () => {
+      const request = makeRequest("/");
+      const response = await proxy(request);
+
+      expect(response.headers.get("Content-Security-Policy")).toBe("default-src 'self';");
+    });
+
+    it("sets CSP header on API route responses", async () => {
+      const request = makeRequest("/healthy");
+      const response = await proxy(request);
+
+      expect(response.headers.get("Content-Security-Policy")).toBe("default-src 'self';");
+    });
+
+    it("sets x-nonce request header for all routes", async () => {
+      const request = makeRequest("/");
+      await proxy(request);
+
+      expect(generateCSP).toHaveBeenCalledOnce();
+    });
+
+    it("sets CSP on proxy path when multitenancy env vars are absent", async () => {
+      const request = makeRequest("/oidc/v1/authorize");
+      const response = await proxy(request);
+
+      expect(response.headers.get("Content-Security-Policy")).toBe("default-src 'self';");
+    });
+
+    it("sets CSP on proxy path when multitenancy env vars are present", async () => {
+      process.env.ZITADEL_API_URL = "https://idp.example.com";
+      process.env.ZITADEL_SERVICE_USER_TOKEN = "token";
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ settings: null }),
+      });
+
+      const request = makeRequest("/oidc/v1/authorize");
+      const response = await proxy(request);
+
+      expect(response.headers.get("Content-Security-Policy")).toBe("default-src 'self';");
+    });
+
+    it("sets CSP on satisfied auth route responses", async () => {
+      vi.mocked(checkAuthenticationLevel).mockResolvedValue({ satisfied: true });
+
+      const request = makeRequest("/password");
+      const response = await proxy(request);
+
+      expect(response.headers.get("Content-Security-Policy")).toBe("default-src 'self';");
+    });
+
+    it("sets CSP on auth flow route when password is verified", async () => {
+      vi.mocked(checkAuthenticationLevel).mockResolvedValue({
+        satisfied: false,
+        session: { factors: { password: { verifiedAt: {} } } } as never,
+      });
+
+      const request = makeRequest("/mfa");
+      const response = await proxy(request);
+
+      expect(response.headers.get("Content-Security-Policy")).toBe("default-src 'self';");
+    });
+  });
+
+  describe("proxy path (OIDC/SAML)", () => {
+    it("rewrites to Zitadel when env vars are set", async () => {
+      process.env.ZITADEL_API_URL = "https://idp.example.com";
+      process.env.ZITADEL_SERVICE_USER_TOKEN = "token";
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ settings: null }),
+      });
+
+      const request = makeRequest("/oauth/v2/token");
+      const response = await proxy(request);
+
+      expect(response.status).toBe(200);
+    });
+
+    it("skips rewrite when env vars are absent", async () => {
+      const request = makeRequest("/oauth/v2/token");
+      const response = await proxy(request);
+
+      expect(response.headers.get("Content-Security-Policy")).toBe("default-src 'self';");
+    });
+
+    it("modifies frame-ancestors when embedded iframe is enabled", async () => {
+      process.env.ZITADEL_API_URL = "https://idp.example.com";
+      process.env.ZITADEL_SERVICE_USER_TOKEN = "token";
+
+      vi.mocked(generateCSP).mockReturnValue({
+        csp: "default-src 'self'; frame-ancestors 'none';",
+        nonce: "test-nonce",
+      });
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          settings: {
+            embeddedIframe: {
+              enabled: true,
+              allowedOrigins: ["https://app.example.com"],
+            },
+          },
+        }),
+      });
+
+      const request = makeRequest("/oidc/v1/authorize");
+      const response = await proxy(request);
+
+      expect(response.headers.get("Content-Security-Policy")).toContain(
+        "frame-ancestors https://app.example.com;"
+      );
+    });
+  });
+
+  describe("auth checks", () => {
+    it("redirects to login when auth check fails on protected route", async () => {
+      vi.mocked(checkAuthenticationLevel).mockResolvedValue({
+        satisfied: false,
+        session: null,
+        redirect: "/",
+        reason: "No session found",
+      });
+      vi.mocked(getSmartRedirect).mockReturnValue("/");
+
+      const request = makeRequest("/account");
+      const response = await proxy(request);
+
+      expect(response.status).toBe(307);
+    });
+
+    it("forwards x-zitadel-i18n-organization header on all requests", async () => {
+      vi.mocked(checkAuthenticationLevel).mockResolvedValue({ satisfied: true });
+
+      const request = makeRequest("/password");
+      await proxy(request);
+
+      expect(getServiceUrlFromHeaders).toHaveBeenCalled();
+    });
+
+    it("allows password route when session has user factor", async () => {
+      vi.mocked(checkAuthenticationLevel).mockResolvedValue({
+        satisfied: false,
+        session: { factors: { user: { id: "u1" } } } as never,
+      });
+
+      const request = makeRequest("/password");
+      const response = await proxy(request);
+
+      expect(response.headers.get("Content-Security-Policy")).toBe("default-src 'self';");
+    });
+  });
+});

--- a/proxy.test.ts
+++ b/proxy.test.ts
@@ -16,9 +16,13 @@ import { checkAuthenticationLevel, getSmartRedirect } from "./lib/server/route-p
 import { getServiceUrlFromHeaders } from "./lib/service-url";
 import { proxy } from "./proxy";
 
-vi.mock("@lib/cspScripts", () => ({
-  generateCSP: vi.fn(() => ({ csp: "default-src 'self';", nonce: "test-nonce" })),
-}));
+vi.mock("@lib/cspScripts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@lib/cspScripts")>();
+  return {
+    ...actual,
+    generateCSP: vi.fn(() => ({ csp: "default-src 'self';", nonce: "test-nonce" })),
+  };
+});
 
 vi.mock("@lib/logger", () => ({
   logMessage: {

--- a/proxy.test.ts
+++ b/proxy.test.ts
@@ -111,9 +111,11 @@ describe("proxy middleware", () => {
 
     it("sets x-nonce request header for all routes", async () => {
       const request = makeRequest("/");
-      await proxy(request);
+      const response = await proxy(request);
 
       expect(generateCSP).toHaveBeenCalledOnce();
+      expect(response.headers.get("x-middleware-request-x-nonce")).toBe("test-nonce");
+      expect(response.headers.get("x-middleware-override-headers")).toContain("x-nonce");
     });
 
     it("sets CSP on proxy path when multitenancy env vars are absent", async () => {
@@ -233,9 +235,15 @@ describe("proxy middleware", () => {
       vi.mocked(checkAuthenticationLevel).mockResolvedValue({ satisfied: true });
 
       const request = makeRequest("/password");
-      await proxy(request);
+      const response = await proxy(request);
 
       expect(getServiceUrlFromHeaders).toHaveBeenCalled();
+      expect(response.headers.get("x-middleware-override-headers")).toContain(
+        "x-zitadel-i18n-organization"
+      );
+      expect(response.headers.get("x-middleware-request-x-zitadel-i18n-organization")).toBe(
+        "test-org"
+      );
     });
 
     it("allows password route when session has user factor", async () => {

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,9 +1,9 @@
-import { headers } from "next/headers";
 import { NextRequest, NextResponse } from "next/server";
 import { SecuritySettings } from "@zitadel/proto/zitadel/settings/v2/security_settings_pb";
 
 import { ZITADEL_ORGANIZATION } from "@root/constants/config";
 import { generateCSP } from "@lib/cspScripts";
+import { logMessage } from "@lib/logger";
 
 import {
   API_ROUTES,
@@ -42,14 +42,14 @@ async function loadSecuritySettings(request: NextRequest): Promise<SecuritySetti
   const securityResponse = await fetch(`${request.nextUrl.origin}/security`);
 
   if (!securityResponse.ok) {
-    console.error("Failed to fetch security settings:", securityResponse.statusText);
+    logMessage.error(`Failed to fetch security settings: ${securityResponse.statusText}`);
     return null;
   }
 
   const response = await securityResponse.json();
 
   if (!response || !response.settings) {
-    console.error("No security settings found in the response.");
+    logMessage.error("No security settings found in the response.");
     return null;
   }
 
@@ -78,6 +78,10 @@ export async function proxy(request: NextRequest) {
   // Set organization header for Zitadel
   requestHeaders.set("x-zitadel-i18n-organization", ZITADEL_ORGANIZATION);
 
+  // Generate CSP once for this request; propagate nonce to layouts via request header
+  const { csp, nonce } = generateCSP();
+  requestHeaders.set("x-nonce", nonce);
+
   // Only run the proxy logic for OIDC/SAML paths
   const proxyPaths = ["/.well-known/", "/oauth/", "/oidc/", "/idps/callback/", "/saml/"];
   const isProxyPath = proxyPaths.some((prefix) => pathname.startsWith(prefix));
@@ -86,24 +90,22 @@ export async function proxy(request: NextRequest) {
   if (isProxyPath) {
     // escape proxy if the environment is not setup for multitenancy
     if (!process.env.ZITADEL_API_URL || !process.env.ZITADEL_SERVICE_USER_TOKEN) {
-      return NextResponse.next({
-        request: { headers: requestHeaders },
-      });
+      const response = NextResponse.next({ request: { headers: requestHeaders } });
+      response.headers.set("Content-Security-Policy", csp);
+      return response;
     }
 
-    const _headers = await headers();
-    const { serviceUrl } = getServiceUrlFromHeaders(_headers);
+    const { serviceUrl } = getServiceUrlFromHeaders(request.headers);
 
     const instanceHost = `${serviceUrl}`.replace("https://", "").replace("http://", "");
 
     // Add additional headers for proxy
-    requestHeaders.set("x-zitadel-public-host", `https://${_headers.get("host")}`);
+    requestHeaders.set("x-zitadel-public-host", `https://${request.headers.get("host")}`);
     requestHeaders.set("x-zitadel-instance-host", instanceHost);
 
     const responseHeaders = new Headers();
     responseHeaders.set("Access-Control-Allow-Origin", "*");
     responseHeaders.set("Access-Control-Allow-Headers", "*");
-    const { csp } = generateCSP();
 
     const securitySettings = await loadSecuritySettings(request);
 
@@ -132,23 +134,22 @@ export async function proxy(request: NextRequest) {
 
   // Skip auth checks for API routes
   if (matchesPattern(pathname, API_ROUTES)) {
-    return NextResponse.next({
-      request: { headers: requestHeaders },
-    });
+    const response = NextResponse.next({ request: { headers: requestHeaders } });
+    response.headers.set("Content-Security-Policy", csp);
+    return response;
   }
 
   // Get service URL for auth checks
-  const _headers = await headers();
-  const { serviceUrl } = getServiceUrlFromHeaders(_headers);
+  const { serviceUrl } = getServiceUrlFromHeaders(request.headers);
 
   // Determine required authentication level for this route
   const requiredLevel = getRequiredAuthLevel(pathname);
 
   // Skip check for open routes
   if (requiredLevel === AuthLevel.OPEN) {
-    return NextResponse.next({
-      request: { headers: requestHeaders },
-    });
+    const response = NextResponse.next({ request: { headers: requestHeaders } });
+    response.headers.set("Content-Security-Policy", csp);
+    return response;
   }
 
   // Check authentication level (loginName will be extracted from session cookie)
@@ -161,9 +162,9 @@ export async function proxy(request: NextRequest) {
 
   // If satisfied, allow the request
   if (authCheck.satisfied) {
-    return NextResponse.next({
-      request: { headers: requestHeaders },
-    });
+    const response = NextResponse.next({ request: { headers: requestHeaders } });
+    response.headers.set("Content-Security-Policy", csp);
+    return response;
   }
 
   // Special handling for auth flow routes
@@ -197,18 +198,18 @@ export async function proxy(request: NextRequest) {
         }
 
         // Allow access to MFA flow pages when password is already verified
-        return NextResponse.next({
-          request: { headers: requestHeaders },
-        });
+        const response = NextResponse.next({ request: { headers: requestHeaders } });
+        response.headers.set("Content-Security-Policy", csp);
+        return response;
       }
     }
 
     // Allow access to password pages if session exists
     if (pathname.startsWith("/password")) {
       if (authCheck.session?.factors?.user) {
-        return NextResponse.next({
-          request: { headers: requestHeaders },
-        });
+        const response = NextResponse.next({ request: { headers: requestHeaders } });
+        response.headers.set("Content-Security-Policy", csp);
+        return response;
       }
     }
   }

--- a/proxy.ts
+++ b/proxy.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { SecuritySettings } from "@zitadel/proto/zitadel/settings/v2/security_settings_pb";
 
 import { ZITADEL_ORGANIZATION } from "@root/constants/config";
-import { generateCSP } from "@lib/cspScripts";
+import { generateCSP, responseWithCSP } from "@lib/cspScripts";
 import { logMessage } from "@lib/logger";
 
 import {
@@ -90,9 +90,7 @@ export async function proxy(request: NextRequest) {
   if (isProxyPath) {
     // escape proxy if the environment is not setup for multitenancy
     if (!process.env.ZITADEL_API_URL || !process.env.ZITADEL_SERVICE_USER_TOKEN) {
-      const response = NextResponse.next({ request: { headers: requestHeaders } });
-      response.headers.set("Content-Security-Policy", csp);
-      return response;
+      return responseWithCSP(NextResponse.next({ request: { headers: requestHeaders } }), csp);
     }
 
     const { serviceUrl } = getServiceUrlFromHeaders(request.headers);
@@ -134,9 +132,7 @@ export async function proxy(request: NextRequest) {
 
   // Skip auth checks for API routes
   if (matchesPattern(pathname, API_ROUTES)) {
-    const response = NextResponse.next({ request: { headers: requestHeaders } });
-    response.headers.set("Content-Security-Policy", csp);
-    return response;
+    return responseWithCSP(NextResponse.next({ request: { headers: requestHeaders } }), csp);
   }
 
   // Get service URL for auth checks
@@ -147,9 +143,7 @@ export async function proxy(request: NextRequest) {
 
   // Skip check for open routes
   if (requiredLevel === AuthLevel.OPEN) {
-    const response = NextResponse.next({ request: { headers: requestHeaders } });
-    response.headers.set("Content-Security-Policy", csp);
-    return response;
+    return responseWithCSP(NextResponse.next({ request: { headers: requestHeaders } }), csp);
   }
 
   // Check authentication level (loginName will be extracted from session cookie)
@@ -162,9 +156,7 @@ export async function proxy(request: NextRequest) {
 
   // If satisfied, allow the request
   if (authCheck.satisfied) {
-    const response = NextResponse.next({ request: { headers: requestHeaders } });
-    response.headers.set("Content-Security-Policy", csp);
-    return response;
+    return responseWithCSP(NextResponse.next({ request: { headers: requestHeaders } }), csp);
   }
 
   // Special handling for auth flow routes
@@ -198,18 +190,14 @@ export async function proxy(request: NextRequest) {
         }
 
         // Allow access to MFA flow pages when password is already verified
-        const response = NextResponse.next({ request: { headers: requestHeaders } });
-        response.headers.set("Content-Security-Policy", csp);
-        return response;
+        return responseWithCSP(NextResponse.next({ request: { headers: requestHeaders } }), csp);
       }
     }
 
     // Allow access to password pages if session exists
     if (pathname.startsWith("/password")) {
       if (authCheck.session?.factors?.user) {
-        const response = NextResponse.next({ request: { headers: requestHeaders } });
-        response.headers.set("Content-Security-Policy", csp);
-        return response;
+        return responseWithCSP(NextResponse.next({ request: { headers: requestHeaders } }), csp);
       }
     }
   }

--- a/proxy.ts
+++ b/proxy.ts
@@ -216,5 +216,5 @@ export async function proxy(request: NextRequest) {
     });
   }
 
-  return NextResponse.redirect(url);
+  return responseWithCSP(NextResponse.redirect(url), csp);
 }


### PR DESCRIPTION
# Summary
This change updates the proxy so that CSP headers are properly returned for dev and production builds.

# Related
- https://nextjs.org/docs/app/guides/content-security-policy
- https://github.com/cds-snc/platform-core-services/issues/945