### PR TITLE
chore: add strong verify step

### DIFF
--- a/app/(auth)/error.tsx
+++ b/app/(auth)/error.tsx
@@ -28,6 +28,7 @@ export default function Error({ error }: { error: Error & { digest?: string } })
           width={200}
           height={200}
           className="mx-auto mb-6"
+          style={{ height: "auto" }}
           priority
         />
       </div>

--- a/app/(auth)/mfa/set/page.tsx
+++ b/app/(auth)/mfa/set/page.tsx
@@ -10,13 +10,9 @@ import { redirect } from "next/navigation";
  *--------------------------------------------*/
 import { getSessionCredentials } from "@lib/cookies";
 import { logMessage } from "@lib/logger";
-import {
-  AuthLevel,
-  checkAuthenticationLevel,
-  requiresStrongMfaSetupVerification,
-} from "@lib/server/route-protection";
+import { loadMfaSetupSession } from "@lib/server/mfa-setup";
 import { getServiceUrlFromHeaders } from "@lib/service-url";
-import { checkSessionFactorValidity, loadSessionById } from "@lib/session";
+import { checkSessionFactorValidity } from "@lib/session";
 import { getSerializableLoginSettings } from "@lib/zitadel";
 import { serverTranslation } from "@i18n/server";
 import { AuthPanel } from "@components/auth/AuthPanel";
@@ -34,38 +30,25 @@ export async function generateMetadata(): Promise<Metadata> {
 export default async function Page() {
   const _headers = await headers();
   const { serviceUrl } = getServiceUrlFromHeaders(_headers);
-  const { sessionId, loginName, organization, requestId } = await getSessionCredentials();
+  let sessionId: string | undefined;
+  let loginName: string | undefined;
+  let organization: string | undefined;
+  let requestId: string | undefined;
 
-  const passwordAuthCheck = await checkAuthenticationLevel(
+  try {
+    ({ sessionId, loginName, organization, requestId } = await getSessionCredentials());
+  } catch {
+    redirect("/password");
+  }
+
+  const sessionFactors = await loadMfaSetupSession({
     serviceUrl,
-    AuthLevel.PASSWORD_REQUIRED,
+    sessionId,
     loginName,
-    organization
-  );
-
-  if (!passwordAuthCheck.satisfied) {
-    logMessage.debug({
-      message: "MFA set page auth check failed",
-      reason: passwordAuthCheck.reason,
-      redirect: passwordAuthCheck.redirect,
-    });
-    redirect(passwordAuthCheck.redirect || "/password");
-  }
-
-  const sessionFactors = await loadSessionById(serviceUrl, sessionId, organization);
-
-  if (!sessionFactors) {
-    logMessage.debug({
-      message: "MFA set page missing session factors",
-      hasSessionId: !!sessionId,
-      hasOrganization: !!organization,
-    });
-    redirect("/");
-  }
-
-  if (requiresStrongMfaSetupVerification(sessionFactors)) {
-    redirect("/mfa/set/verify");
-  }
+    organization,
+    pageName: "MFA set page",
+    missingSessionRedirect: "/",
+  });
 
   const loginSettings = await getSerializableLoginSettings({
     serviceUrl,

--- a/app/(auth)/mfa/set/page.tsx
+++ b/app/(auth)/mfa/set/page.tsx
@@ -64,15 +64,11 @@ export default async function Page() {
     (method) => sessionFactors.authMethods?.includes(method)
   );
 
-  const fullyAuthenticatedCheck = await checkAuthenticationLevel(
-    serviceUrl,
-    AuthLevel.ANY_MFA_REQUIRED,
-    loginName,
-    organization
-  );
+  const hasVerifiedStrongMFA =
+    !!sessionFactors.factors?.totp?.verifiedAt || !!sessionFactors.factors?.webAuthN?.verifiedAt;
 
-  if (!fullyAuthenticatedCheck.satisfied && hasConfiguredStrongMFA) {
-    redirect(fullyAuthenticatedCheck.redirect || "/mfa");
+  if (hasConfiguredStrongMFA && !hasVerifiedStrongMFA) {
+    redirect("/mfa/set/verify");
   }
 
   const loginSettings = await getSerializableLoginSettings({

--- a/app/(auth)/mfa/set/page.tsx
+++ b/app/(auth)/mfa/set/page.tsx
@@ -4,14 +4,17 @@
 import { Metadata } from "next";
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
-import { AuthenticationMethodType } from "@zitadel/proto/zitadel/user/v2/user_service_pb";
 
 /*--------------------------------------------*
  * Internal Aliases
  *--------------------------------------------*/
 import { getSessionCredentials } from "@lib/cookies";
 import { logMessage } from "@lib/logger";
-import { AuthLevel, checkAuthenticationLevel } from "@lib/server/route-protection";
+import {
+  AuthLevel,
+  checkAuthenticationLevel,
+  requiresStrongMfaSetupVerification,
+} from "@lib/server/route-protection";
 import { getServiceUrlFromHeaders } from "@lib/service-url";
 import { checkSessionFactorValidity, loadSessionById } from "@lib/session";
 import { getSerializableLoginSettings } from "@lib/zitadel";
@@ -60,14 +63,7 @@ export default async function Page() {
     redirect("/");
   }
 
-  const hasConfiguredStrongMFA = [AuthenticationMethodType.TOTP, AuthenticationMethodType.U2F].some(
-    (method) => sessionFactors.authMethods?.includes(method)
-  );
-
-  const hasVerifiedStrongMFA =
-    !!sessionFactors.factors?.totp?.verifiedAt || !!sessionFactors.factors?.webAuthN?.verifiedAt;
-
-  if (hasConfiguredStrongMFA && !hasVerifiedStrongMFA) {
+  if (requiresStrongMfaSetupVerification(sessionFactors)) {
     redirect("/mfa/set/verify");
   }
 

--- a/app/(auth)/mfa/set/verify/page.tsx
+++ b/app/(auth)/mfa/set/verify/page.tsx
@@ -9,11 +9,9 @@ import { AuthenticationMethodType } from "@zitadel/proto/zitadel/user/v2/user_se
 /*--------------------------------------------*
  * Internal Aliases
  *--------------------------------------------*/
-import { getSessionCredentials } from "@lib/cookies";
 import { logMessage } from "@lib/logger";
-import { AuthLevel, checkAuthenticationLevel } from "@lib/server/route-protection";
+import { loadMfaVerificationSession } from "@lib/server/mfa-verify";
 import { getServiceUrlFromHeaders } from "@lib/service-url";
-import { loadSessionById, loadSessionByLoginname } from "@lib/session";
 import { serverTranslation } from "@i18n/server";
 import { AuthPanel } from "@components/auth/AuthPanel";
 import { StrongFactorSelection } from "@components/mfa/StrongFactorSelection";
@@ -24,33 +22,14 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 export default async function Page() {
-  let sessionId: string | undefined;
-  let loginName: string | undefined;
-  let organization: string | undefined;
-
-  try {
-    ({ sessionId, loginName, organization } = await getSessionCredentials());
-  } catch {
-    redirect("/password");
-  }
-
   const _headers = await headers();
   const { serviceUrl } = getServiceUrlFromHeaders(_headers);
 
-  const authCheck = await checkAuthenticationLevel(
+  const { sessionData } = await loadMfaVerificationSession({
     serviceUrl,
-    AuthLevel.PASSWORD_REQUIRED,
-    loginName,
-    organization
-  );
-
-  if (!authCheck.satisfied) {
-    redirect(authCheck.redirect || "/password");
-  }
-
-  const sessionData = sessionId
-    ? await loadSessionById(serviceUrl, sessionId, organization)
-    : await loadSessionByLoginname(serviceUrl, loginName, organization);
+    pageName: "MFA setup verify page",
+    missingSessionRedirect: "/mfa/set",
+  });
 
   const canUseTotp = sessionData.authMethods?.includes(AuthenticationMethodType.TOTP) ?? false;
   const canUseU2F = sessionData.authMethods?.includes(AuthenticationMethodType.U2F) ?? false;

--- a/app/(auth)/mfa/set/verify/page.tsx
+++ b/app/(auth)/mfa/set/verify/page.tsx
@@ -1,0 +1,73 @@
+/*--------------------------------------------*
+ * Framework and Third-Party
+ *--------------------------------------------*/
+import { Metadata } from "next";
+import { headers } from "next/headers";
+import { redirect } from "next/navigation";
+import { AuthenticationMethodType } from "@zitadel/proto/zitadel/user/v2/user_service_pb";
+
+/*--------------------------------------------*
+ * Internal Aliases
+ *--------------------------------------------*/
+import { getSessionCredentials } from "@lib/cookies";
+import { logMessage } from "@lib/logger";
+import { AuthLevel, checkAuthenticationLevel } from "@lib/server/route-protection";
+import { getServiceUrlFromHeaders } from "@lib/service-url";
+import { loadSessionById, loadSessionByLoginname } from "@lib/session";
+import { serverTranslation } from "@i18n/server";
+import { AuthPanel } from "@components/auth/AuthPanel";
+import { StrongFactorSelection } from "@components/mfa/StrongFactorSelection";
+
+export async function generateMetadata(): Promise<Metadata> {
+  const { t } = await serverTranslation("mfa");
+  return { title: t("verify.title") };
+}
+
+export default async function Page() {
+  let sessionId: string | undefined;
+  let loginName: string | undefined;
+  let organization: string | undefined;
+
+  try {
+    ({ sessionId, loginName, organization } = await getSessionCredentials());
+  } catch {
+    redirect("/password");
+  }
+
+  const _headers = await headers();
+  const { serviceUrl } = getServiceUrlFromHeaders(_headers);
+
+  const authCheck = await checkAuthenticationLevel(
+    serviceUrl,
+    AuthLevel.PASSWORD_REQUIRED,
+    loginName,
+    organization
+  );
+
+  if (!authCheck.satisfied) {
+    redirect(authCheck.redirect || "/password");
+  }
+
+  const sessionData = sessionId
+    ? await loadSessionById(serviceUrl, sessionId, organization)
+    : await loadSessionByLoginname(serviceUrl, loginName, organization);
+
+  const canUseTotp = sessionData.authMethods?.includes(AuthenticationMethodType.TOTP) ?? false;
+  const canUseU2F = sessionData.authMethods?.includes(AuthenticationMethodType.U2F) ?? false;
+
+  if (!sessionData.factors?.user?.id || (!canUseTotp && !canUseU2F)) {
+    logMessage.info("MFA setup verification requires at least one configured strong MFA method");
+    redirect("/mfa/set");
+  }
+
+  return (
+    <AuthPanel titleI18nKey="verify.title" descriptionI18nKey="verify.description" namespace="mfa">
+      <StrongFactorSelection
+        canUseTotp={canUseTotp}
+        canUseU2F={canUseU2F}
+        totpUrl="/mfa/set/verify/time-based"
+        u2fUrl="/mfa/set/verify/u2f"
+      />
+    </AuthPanel>
+  );
+}

--- a/app/(auth)/mfa/set/verify/time-based/page.tsx
+++ b/app/(auth)/mfa/set/verify/time-based/page.tsx
@@ -9,11 +9,9 @@ import { AuthenticationMethodType } from "@zitadel/proto/zitadel/user/v2/user_se
 /*--------------------------------------------*
  * Internal Aliases
  *--------------------------------------------*/
-import { getSessionCredentials } from "@lib/cookies";
 import { getOriginalHostFromHeaders } from "@lib/server/host";
-import { AuthLevel, checkAuthenticationLevel } from "@lib/server/route-protection";
+import { loadMfaVerificationSession } from "@lib/server/mfa-verify";
 import { getServiceUrlFromHeaders } from "@lib/service-url";
-import { loadSessionById, loadSessionByLoginname } from "@lib/session";
 import { resolveSiteConfigByHost } from "@lib/site-config";
 import { getSerializableObject } from "@lib/utils";
 import { getLoginSettings } from "@lib/zitadel";
@@ -27,35 +25,16 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 export default async function Page() {
-  let sessionId: string | undefined;
-  let loginName: string | undefined;
-  let organization: string | undefined;
-
-  try {
-    ({ sessionId, loginName, organization } = await getSessionCredentials());
-  } catch {
-    redirect("/password");
-  }
-
   const _headers = await headers();
   const { serviceUrl } = getServiceUrlFromHeaders(_headers);
   const resolvedHost = getOriginalHostFromHeaders(_headers);
   const siteConfig = resolveSiteConfigByHost(resolvedHost);
 
-  const authCheck = await checkAuthenticationLevel(
+  const { sessionId, loginName, organization, sessionData } = await loadMfaVerificationSession({
     serviceUrl,
-    AuthLevel.PASSWORD_REQUIRED,
-    loginName,
-    organization
-  );
-
-  if (!authCheck.satisfied) {
-    redirect(authCheck.redirect || "/password");
-  }
-
-  const sessionData = sessionId
-    ? await loadSessionById(serviceUrl, sessionId, organization)
-    : await loadSessionByLoginname(serviceUrl, loginName, organization);
+    pageName: "TOTP verify page",
+    missingSessionRedirect: "/mfa/set/verify",
+  });
 
   if (!sessionData.authMethods?.includes(AuthenticationMethodType.TOTP)) {
     redirect("/mfa/set/verify");

--- a/app/(auth)/mfa/set/verify/time-based/page.tsx
+++ b/app/(auth)/mfa/set/verify/time-based/page.tsx
@@ -1,0 +1,88 @@
+/*--------------------------------------------*
+ * Framework and Third-Party
+ *--------------------------------------------*/
+import { Metadata } from "next";
+import { headers } from "next/headers";
+import { redirect } from "next/navigation";
+import { AuthenticationMethodType } from "@zitadel/proto/zitadel/user/v2/user_service_pb";
+
+/*--------------------------------------------*
+ * Internal Aliases
+ *--------------------------------------------*/
+import { getSessionCredentials } from "@lib/cookies";
+import { getOriginalHostFromHeaders } from "@lib/server/host";
+import { AuthLevel, checkAuthenticationLevel } from "@lib/server/route-protection";
+import { getServiceUrlFromHeaders } from "@lib/service-url";
+import { loadSessionById, loadSessionByLoginname } from "@lib/session";
+import { resolveSiteConfigByHost } from "@lib/site-config";
+import { getSerializableObject } from "@lib/utils";
+import { getLoginSettings } from "@lib/zitadel";
+import { serverTranslation } from "@i18n/server";
+import { AuthPanel } from "@components/auth/AuthPanel";
+import { LoginOTP } from "@components/mfa/LoginOTP";
+
+export async function generateMetadata(): Promise<Metadata> {
+  const { t } = await serverTranslation("otp");
+  return { title: t("verify.authAppTitle") };
+}
+
+export default async function Page() {
+  let sessionId: string | undefined;
+  let loginName: string | undefined;
+  let organization: string | undefined;
+
+  try {
+    ({ sessionId, loginName, organization } = await getSessionCredentials());
+  } catch {
+    redirect("/password");
+  }
+
+  const _headers = await headers();
+  const { serviceUrl } = getServiceUrlFromHeaders(_headers);
+  const resolvedHost = getOriginalHostFromHeaders(_headers);
+  const siteConfig = resolveSiteConfigByHost(resolvedHost);
+
+  const authCheck = await checkAuthenticationLevel(
+    serviceUrl,
+    AuthLevel.PASSWORD_REQUIRED,
+    loginName,
+    organization
+  );
+
+  if (!authCheck.satisfied) {
+    redirect(authCheck.redirect || "/password");
+  }
+
+  const sessionData = sessionId
+    ? await loadSessionById(serviceUrl, sessionId, organization)
+    : await loadSessionByLoginname(serviceUrl, loginName, organization);
+
+  if (!sessionData.authMethods?.includes(AuthenticationMethodType.TOTP)) {
+    redirect("/mfa/set/verify");
+  }
+
+  const loginSettings = await getLoginSettings({
+    serviceUrl,
+    organization: organization ?? sessionData.factors?.user?.organizationId,
+  }).then((obj) => getSerializableObject(obj));
+
+  return (
+    <AuthPanel
+      titleI18nKey="verify.authAppTitle"
+      descriptionI18nKey="none"
+      namespace="otp"
+      imageSrc="/img/auth-app-icon.png"
+    >
+      <LoginOTP
+        loginName={loginName ?? sessionData.factors?.user?.loginName}
+        sessionId={sessionId}
+        organization={organization ?? sessionData.factors?.user?.organizationId}
+        method="time-based"
+        loginSettings={loginSettings}
+        redirect="/mfa/set"
+        displayName={sessionData.factors?.user?.displayName}
+        siteConfig={siteConfig}
+      />
+    </AuthPanel>
+  );
+}

--- a/app/(auth)/mfa/set/verify/u2f/page.tsx
+++ b/app/(auth)/mfa/set/verify/u2f/page.tsx
@@ -9,10 +9,8 @@ import { AuthenticationMethodType } from "@zitadel/proto/zitadel/user/v2/user_se
 /*--------------------------------------------*
  * Internal Aliases
  *--------------------------------------------*/
-import { getSessionCredentials } from "@lib/cookies";
-import { AuthLevel, checkAuthenticationLevel } from "@lib/server/route-protection";
+import { loadMfaVerificationSession } from "@lib/server/mfa-verify";
 import { getServiceUrlFromHeaders } from "@lib/service-url";
-import { loadSessionById, loadSessionByLoginname } from "@lib/session";
 import { serverTranslation } from "@i18n/server";
 import { UserAvatar } from "@components/account/user-avatar/UserAvatar";
 import { AuthPanel } from "@components/auth/AuthPanel";
@@ -24,33 +22,14 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 export default async function Page() {
-  let sessionId: string | undefined;
-  let loginName: string | undefined;
-  let organization: string | undefined;
-
-  try {
-    ({ sessionId, loginName, organization } = await getSessionCredentials());
-  } catch {
-    redirect("/password");
-  }
-
   const _headers = await headers();
   const { serviceUrl } = getServiceUrlFromHeaders(_headers);
 
-  const authCheck = await checkAuthenticationLevel(
+  const { sessionId, loginName, organization, sessionData } = await loadMfaVerificationSession({
     serviceUrl,
-    AuthLevel.PASSWORD_REQUIRED,
-    loginName,
-    organization
-  );
-
-  if (!authCheck.satisfied) {
-    redirect(authCheck.redirect || "/password");
-  }
-
-  const sessionData = sessionId
-    ? await loadSessionById(serviceUrl, sessionId, organization)
-    : await loadSessionByLoginname(serviceUrl, loginName, organization);
+    pageName: "U2F verify page",
+    missingSessionRedirect: "/mfa/set/verify",
+  });
 
   if (!sessionData.authMethods?.includes(AuthenticationMethodType.U2F)) {
     redirect("/mfa/set/verify");

--- a/app/(auth)/mfa/set/verify/u2f/page.tsx
+++ b/app/(auth)/mfa/set/verify/u2f/page.tsx
@@ -1,0 +1,82 @@
+/*--------------------------------------------*
+ * Framework and Third-Party
+ *--------------------------------------------*/
+import { Metadata } from "next";
+import { headers } from "next/headers";
+import { redirect } from "next/navigation";
+import { AuthenticationMethodType } from "@zitadel/proto/zitadel/user/v2/user_service_pb";
+
+/*--------------------------------------------*
+ * Internal Aliases
+ *--------------------------------------------*/
+import { getSessionCredentials } from "@lib/cookies";
+import { AuthLevel, checkAuthenticationLevel } from "@lib/server/route-protection";
+import { getServiceUrlFromHeaders } from "@lib/service-url";
+import { loadSessionById, loadSessionByLoginname } from "@lib/session";
+import { serverTranslation } from "@i18n/server";
+import { UserAvatar } from "@components/account/user-avatar/UserAvatar";
+import { AuthPanel } from "@components/auth/AuthPanel";
+import { LoginU2F } from "@components/mfa/LoginU2F";
+
+export async function generateMetadata(): Promise<Metadata> {
+  const { t } = await serverTranslation("u2f");
+  return { title: t("verify.title") };
+}
+
+export default async function Page() {
+  let sessionId: string | undefined;
+  let loginName: string | undefined;
+  let organization: string | undefined;
+
+  try {
+    ({ sessionId, loginName, organization } = await getSessionCredentials());
+  } catch {
+    redirect("/password");
+  }
+
+  const _headers = await headers();
+  const { serviceUrl } = getServiceUrlFromHeaders(_headers);
+
+  const authCheck = await checkAuthenticationLevel(
+    serviceUrl,
+    AuthLevel.PASSWORD_REQUIRED,
+    loginName,
+    organization
+  );
+
+  if (!authCheck.satisfied) {
+    redirect(authCheck.redirect || "/password");
+  }
+
+  const sessionData = sessionId
+    ? await loadSessionById(serviceUrl, sessionId, organization)
+    : await loadSessionByLoginname(serviceUrl, loginName, organization);
+
+  if (!sessionData.authMethods?.includes(AuthenticationMethodType.U2F)) {
+    redirect("/mfa/set/verify");
+  }
+
+  return (
+    <AuthPanel
+      titleI18nKey="verify.title"
+      descriptionI18nKey="none"
+      namespace="u2f"
+      imageSrc="/img/key-icon.png"
+    >
+      <UserAvatar
+        loginName={loginName ?? sessionData.factors?.user?.loginName}
+        displayName={sessionData.factors?.user?.displayName}
+        showDropdown={false}
+      />
+      <div className="w-full">
+        <LoginU2F
+          loginName={loginName}
+          sessionId={sessionId}
+          organization={organization}
+          login={false}
+          redirect="/mfa/set"
+        />
+      </div>
+    </AuthPanel>
+  );
+}

--- a/app/(auth)/otp/[method]/page.tsx
+++ b/app/(auth)/otp/[method]/page.tsx
@@ -17,11 +17,7 @@ import { getSerializableObject, SearchParams } from "@lib/utils";
 import { getLoginSettings } from "@lib/zitadel";
 import { serverTranslation } from "@i18n/server";
 import { AuthPanel } from "@components/auth/AuthPanel";
-
-/*--------------------------------------------*
- * Local Relative
- *--------------------------------------------*/
-import { LoginOTP } from "./components/LoginOTP";
+import { LoginOTP } from "@components/mfa/LoginOTP";
 
 export async function generateMetadata(): Promise<Metadata> {
   const { t } = await serverTranslation("otp");

--- a/app/(auth)/otp/[method]/set/page.tsx
+++ b/app/(auth)/otp/[method]/set/page.tsx
@@ -12,14 +12,9 @@ import { type RegisterTOTPResponse } from "@zitadel/proto/zitadel/user/v2/user_s
 import { LOGGED_IN_HOME_PAGE } from "@root/constants/config";
 import { getSessionCredentials } from "@lib/cookies";
 import { logMessage } from "@lib/logger";
-import {
-  AuthLevel,
-  checkAuthenticationLevel,
-  requiresStrongMfaSetupVerification,
-} from "@lib/server/route-protection";
+import { loadMfaSetupSession } from "@lib/server/mfa-setup";
 import { protectedAddOTPEmail } from "@lib/server/zitadel-protected";
 import { getServiceUrlFromHeaders } from "@lib/service-url";
-import { loadMostRecentSession } from "@lib/session";
 import { buildUrlWithRequestId } from "@lib/utils";
 import { registerTOTP } from "@lib/zitadel";
 import { getZitadelUiError } from "@lib/zitadel-errors";
@@ -43,7 +38,17 @@ export default async function Page(props: {
   const params = await props.params;
   const searchParams = await props.searchParams;
 
-  const { loginName, organization, requestId } = await getSessionCredentials();
+  let sessionId: string | undefined;
+  let loginName: string | undefined;
+  let organization: string | undefined;
+  let requestId: string | undefined;
+
+  try {
+    ({ sessionId, loginName, organization, requestId } = await getSessionCredentials());
+  } catch {
+    redirect("/password");
+  }
+
   const checkAfter = searchParams.checkAfter === "true";
 
   const { method } = params;
@@ -52,38 +57,14 @@ export default async function Page(props: {
   const _headers = await headers();
   const { serviceUrl } = getServiceUrlFromHeaders(_headers);
 
-  const authCheck = await checkAuthenticationLevel(
+  const session = await loadMfaSetupSession({
     serviceUrl,
-    AuthLevel.PASSWORD_REQUIRED,
+    sessionId,
     loginName,
-    organization
-  );
-
-  if (!authCheck.satisfied) {
-    logMessage.debug({
-      message: "OTP setup page auth check failed",
-      method,
-      reason: authCheck.reason,
-      redirect: authCheck.redirect,
-    });
-    redirect(authCheck.redirect || "/password");
-  }
-
-  const session = await loadMostRecentSession({
-    serviceUrl,
-    sessionParams: {
-      loginName,
-      organization,
-    },
+    organization,
+    pageName: "OTP setup page",
+    missingSessionRedirect: "/mfa/set",
   });
-
-  if (requiresStrongMfaSetupVerification(session)) {
-    logMessage.debug({
-      message: "OTP setup requires strong MFA re-verification",
-      method,
-    });
-    redirect("/mfa/set/verify");
-  }
 
   let totpResponse: RegisterTOTPResponse | undefined,
     error: Error | undefined,

--- a/app/(auth)/otp/[method]/set/page.tsx
+++ b/app/(auth)/otp/[method]/set/page.tsx
@@ -12,7 +12,11 @@ import { type RegisterTOTPResponse } from "@zitadel/proto/zitadel/user/v2/user_s
 import { LOGGED_IN_HOME_PAGE } from "@root/constants/config";
 import { getSessionCredentials } from "@lib/cookies";
 import { logMessage } from "@lib/logger";
-import { AuthLevel, checkAuthenticationLevel } from "@lib/server/route-protection";
+import {
+  AuthLevel,
+  checkAuthenticationLevel,
+  requiresStrongMfaSetupVerification,
+} from "@lib/server/route-protection";
 import { protectedAddOTPEmail } from "@lib/server/zitadel-protected";
 import { getServiceUrlFromHeaders } from "@lib/service-url";
 import { loadMostRecentSession } from "@lib/session";
@@ -72,6 +76,14 @@ export default async function Page(props: {
       organization,
     },
   });
+
+  if (requiresStrongMfaSetupVerification(session)) {
+    logMessage.debug({
+      message: "OTP setup requires strong MFA re-verification",
+      method,
+    });
+    redirect("/mfa/set/verify");
+  }
 
   let totpResponse: RegisterTOTPResponse | undefined,
     error: Error | undefined,

--- a/app/(auth)/password/change/page.test.tsx
+++ b/app/(auth)/password/change/page.test.tsx
@@ -1,10 +1,12 @@
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 import { render, screen } from "@testing-library/react";
+import { create } from "@zitadel/client";
+import { SessionSchema } from "@zitadel/proto/zitadel/session/v2/session_pb";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { getSessionCredentials } from "@lib/cookies";
-import { AuthLevel, checkAuthenticationLevel } from "@lib/server/route-protection";
+import { AuthLevel, checkAuthenticationLevel, hasStrongMFA } from "@lib/server/route-protection";
 import { getServiceUrlFromHeaders } from "@lib/service-url";
 import { getPasswordComplexitySettings } from "@lib/zitadel";
 
@@ -31,6 +33,7 @@ vi.mock("@lib/server/route-protection", () => ({
     PASSWORD_REQUIRED: "password_required",
   },
   checkAuthenticationLevel: vi.fn(),
+  hasStrongMFA: vi.fn(),
 }));
 
 vi.mock("@lib/zitadel", () => ({
@@ -66,6 +69,23 @@ vi.mock("./components/ChangePasswordForm", () => ({
 }));
 
 describe("password/change page", () => {
+  const strongMfaSession = create(SessionSchema, {
+    id: "session-123",
+    factors: {
+      user: { id: "user-123", loginName: "person@canada.ca", organizationId: "org-1" },
+      password: { verifiedAt: { seconds: BigInt(1), nanos: 0 } },
+      totp: { verifiedAt: { seconds: BigInt(1), nanos: 0 } },
+    },
+  });
+
+  const passwordOnlySession = create(SessionSchema, {
+    id: "session-123",
+    factors: {
+      user: { id: "user-123", loginName: "person@canada.ca", organizationId: "org-1" },
+      password: { verifiedAt: { seconds: BigInt(1), nanos: 0 } },
+    },
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
 
@@ -79,7 +99,9 @@ describe("password/change page", () => {
 
     vi.mocked(checkAuthenticationLevel).mockResolvedValue({
       satisfied: true,
+      session: strongMfaSession,
     } as never);
+    vi.mocked(hasStrongMFA).mockReturnValue(true);
 
     vi.mocked(getPasswordComplexitySettings).mockResolvedValue({} as never);
 
@@ -114,6 +136,18 @@ describe("password/change page", () => {
 
     await expect(Page()).rejects.toThrow("NEXT_REDIRECT");
     expect(redirect).toHaveBeenCalledWith("/password");
+  });
+
+  it("redirects to strong MFA verification when only password is verified", async () => {
+    vi.mocked(checkAuthenticationLevel).mockResolvedValue({
+      satisfied: true,
+      session: passwordOnlySession,
+    } as never);
+    vi.mocked(hasStrongMFA).mockReturnValue(false);
+
+    await expect(Page()).rejects.toThrow("NEXT_REDIRECT");
+
+    expect(redirect).toHaveBeenCalledWith("/password/change/verify");
   });
 
   it("renders change password form when auth and session context are valid", async () => {

--- a/app/(auth)/password/change/page.tsx
+++ b/app/(auth)/password/change/page.tsx
@@ -10,7 +10,7 @@ import { redirect } from "next/navigation";
  *--------------------------------------------*/
 import { getSessionCredentials } from "@lib/cookies";
 import { logMessage } from "@lib/logger";
-import { AuthLevel, checkAuthenticationLevel } from "@lib/server/route-protection";
+import { AuthLevel, checkAuthenticationLevel, hasStrongMFA } from "@lib/server/route-protection";
 import { getServiceUrlFromHeaders } from "@lib/service-url";
 import { getPasswordComplexitySettings } from "@lib/zitadel";
 import { serverTranslation } from "@i18n/server";
@@ -40,6 +40,10 @@ export default async function Page() {
 
   if (!authCheck.satisfied) {
     redirect(authCheck.redirect || "/password");
+  }
+
+  if (!hasStrongMFA(authCheck.session ?? null)) {
+    redirect("/password/change/verify");
   }
 
   const passwordComplexitySettings = await getPasswordComplexitySettings({

--- a/app/(auth)/password/change/verify/page.tsx
+++ b/app/(auth)/password/change/verify/page.tsx
@@ -11,6 +11,7 @@ import { AuthenticationMethodType } from "@zitadel/proto/zitadel/user/v2/user_se
  *--------------------------------------------*/
 import { getSessionCredentials } from "@lib/cookies";
 import { logMessage } from "@lib/logger";
+import { AuthLevel, checkAuthenticationLevel } from "@lib/server/route-protection";
 import { getServiceUrlFromHeaders } from "@lib/service-url";
 import { loadSessionById, loadSessionByLoginname } from "@lib/session";
 import { serverTranslation } from "@i18n/server";
@@ -30,11 +31,22 @@ export default async function Page() {
   try {
     ({ sessionId, loginName, organization } = await getSessionCredentials());
   } catch {
-    redirect("/password/reset");
+    redirect("/password");
   }
 
   const _headers = await headers();
   const { serviceUrl } = getServiceUrlFromHeaders(_headers);
+
+  const authCheck = await checkAuthenticationLevel(
+    serviceUrl,
+    AuthLevel.PASSWORD_REQUIRED,
+    loginName,
+    organization
+  );
+
+  if (!authCheck.satisfied) {
+    redirect(authCheck.redirect || "/password");
+  }
 
   const sessionData = sessionId
     ? await loadSessionById(serviceUrl, sessionId, organization)
@@ -44,8 +56,8 @@ export default async function Page() {
   const canUseU2F = sessionData.authMethods?.includes(AuthenticationMethodType.U2F) ?? false;
 
   if (!sessionData.factors?.user?.id || (!canUseTotp && !canUseU2F)) {
-    logMessage.info("Password reset recovery requires at least one strong MFA method");
-    redirect("/password/reset");
+    logMessage.info("Password change requires at least one configured strong MFA method");
+    redirect("/account");
   }
 
   return (
@@ -53,8 +65,8 @@ export default async function Page() {
       <StrongFactorSelection
         canUseTotp={canUseTotp}
         canUseU2F={canUseU2F}
-        totpUrl="/password/reset/verify/time-based"
-        u2fUrl="/password/reset/verify/u2f"
+        totpUrl="/password/change/verify/time-based"
+        u2fUrl="/password/change/verify/u2f"
       />
     </AuthPanel>
   );

--- a/app/(auth)/password/change/verify/time-based/page.tsx
+++ b/app/(auth)/password/change/verify/time-based/page.tsx
@@ -10,16 +10,20 @@ import { AuthenticationMethodType } from "@zitadel/proto/zitadel/user/v2/user_se
  * Internal Aliases
  *--------------------------------------------*/
 import { getSessionCredentials } from "@lib/cookies";
+import { getOriginalHostFromHeaders } from "@lib/server/host";
+import { AuthLevel, checkAuthenticationLevel } from "@lib/server/route-protection";
 import { getServiceUrlFromHeaders } from "@lib/service-url";
 import { loadSessionById, loadSessionByLoginname } from "@lib/session";
+import { resolveSiteConfigByHost } from "@lib/site-config";
+import { getSerializableObject } from "@lib/utils";
+import { getLoginSettings } from "@lib/zitadel";
 import { serverTranslation } from "@i18n/server";
-import { UserAvatar } from "@components/account/user-avatar";
 import { AuthPanel } from "@components/auth/AuthPanel";
-import { LoginU2F } from "@components/mfa/LoginU2F";
+import { LoginOTP } from "@components/mfa/LoginOTP";
 
 export async function generateMetadata(): Promise<Metadata> {
-  const { t } = await serverTranslation("u2f");
-  return { title: t("verify.title") };
+  const { t } = await serverTranslation("otp");
+  return { title: t("verify.authAppTitle") };
 }
 
 export default async function Page() {
@@ -30,41 +34,55 @@ export default async function Page() {
   try {
     ({ sessionId, loginName, organization } = await getSessionCredentials());
   } catch {
-    redirect("/password/reset");
+    redirect("/password");
   }
 
   const _headers = await headers();
   const { serviceUrl } = getServiceUrlFromHeaders(_headers);
+  const resolvedHost = getOriginalHostFromHeaders(_headers);
+  const siteConfig = resolveSiteConfigByHost(resolvedHost);
+
+  const authCheck = await checkAuthenticationLevel(
+    serviceUrl,
+    AuthLevel.PASSWORD_REQUIRED,
+    loginName,
+    organization
+  );
+
+  if (!authCheck.satisfied) {
+    redirect(authCheck.redirect || "/password");
+  }
 
   const sessionData = sessionId
     ? await loadSessionById(serviceUrl, sessionId, organization)
     : await loadSessionByLoginname(serviceUrl, loginName, organization);
 
-  if (!sessionData.authMethods?.includes(AuthenticationMethodType.U2F)) {
-    redirect("/password/reset/verify");
+  if (!sessionData.authMethods?.includes(AuthenticationMethodType.TOTP)) {
+    redirect("/password/change/verify");
   }
+
+  const loginSettings = await getLoginSettings({
+    serviceUrl,
+    organization: organization ?? sessionData.factors?.user?.organizationId,
+  }).then((obj) => getSerializableObject(obj));
 
   return (
     <AuthPanel
-      titleI18nKey="verify.title"
+      titleI18nKey="verify.authAppTitle"
       descriptionI18nKey="none"
-      namespace="u2f"
-      imageSrc="/img/key-icon.png"
+      namespace="otp"
+      imageSrc="/img/auth-app-icon.png"
     >
-      <UserAvatar
+      <LoginOTP
         loginName={loginName ?? sessionData.factors?.user?.loginName}
+        sessionId={sessionId}
+        organization={organization ?? sessionData.factors?.user?.organizationId}
+        method="time-based"
+        loginSettings={loginSettings}
+        redirect="/password/change"
         displayName={sessionData.factors?.user?.displayName}
-        showDropdown={false}
+        siteConfig={siteConfig}
       />
-      <div className="w-full">
-        <LoginU2F
-          loginName={loginName}
-          sessionId={sessionId}
-          organization={organization}
-          login={false}
-          redirect="/password/reset/set"
-        />
-      </div>
     </AuthPanel>
   );
 }

--- a/app/(auth)/password/change/verify/u2f/page.tsx
+++ b/app/(auth)/password/change/verify/u2f/page.tsx
@@ -10,15 +10,16 @@ import { AuthenticationMethodType } from "@zitadel/proto/zitadel/user/v2/user_se
  * Internal Aliases
  *--------------------------------------------*/
 import { getSessionCredentials } from "@lib/cookies";
-import { logMessage } from "@lib/logger";
+import { AuthLevel, checkAuthenticationLevel } from "@lib/server/route-protection";
 import { getServiceUrlFromHeaders } from "@lib/service-url";
 import { loadSessionById, loadSessionByLoginname } from "@lib/session";
 import { serverTranslation } from "@i18n/server";
+import { UserAvatar } from "@components/account/user-avatar";
 import { AuthPanel } from "@components/auth/AuthPanel";
-import { StrongFactorSelection } from "@components/mfa/StrongFactorSelection";
+import { LoginU2F } from "@components/mfa/LoginU2F";
 
 export async function generateMetadata(): Promise<Metadata> {
-  const { t } = await serverTranslation("mfa");
+  const { t } = await serverTranslation("u2f");
   return { title: t("verify.title") };
 }
 
@@ -30,32 +31,52 @@ export default async function Page() {
   try {
     ({ sessionId, loginName, organization } = await getSessionCredentials());
   } catch {
-    redirect("/password/reset");
+    redirect("/password");
   }
 
   const _headers = await headers();
   const { serviceUrl } = getServiceUrlFromHeaders(_headers);
 
+  const authCheck = await checkAuthenticationLevel(
+    serviceUrl,
+    AuthLevel.PASSWORD_REQUIRED,
+    loginName,
+    organization
+  );
+
+  if (!authCheck.satisfied) {
+    redirect(authCheck.redirect || "/password");
+  }
+
   const sessionData = sessionId
     ? await loadSessionById(serviceUrl, sessionId, organization)
     : await loadSessionByLoginname(serviceUrl, loginName, organization);
 
-  const canUseTotp = sessionData.authMethods?.includes(AuthenticationMethodType.TOTP) ?? false;
-  const canUseU2F = sessionData.authMethods?.includes(AuthenticationMethodType.U2F) ?? false;
-
-  if (!sessionData.factors?.user?.id || (!canUseTotp && !canUseU2F)) {
-    logMessage.info("Password reset recovery requires at least one strong MFA method");
-    redirect("/password/reset");
+  if (!sessionData.authMethods?.includes(AuthenticationMethodType.U2F)) {
+    redirect("/password/change/verify");
   }
 
   return (
-    <AuthPanel titleI18nKey="verify.title" descriptionI18nKey="verify.description" namespace="mfa">
-      <StrongFactorSelection
-        canUseTotp={canUseTotp}
-        canUseU2F={canUseU2F}
-        totpUrl="/password/reset/verify/time-based"
-        u2fUrl="/password/reset/verify/u2f"
+    <AuthPanel
+      titleI18nKey="verify.title"
+      descriptionI18nKey="none"
+      namespace="u2f"
+      imageSrc="/img/key-icon.png"
+    >
+      <UserAvatar
+        loginName={loginName ?? sessionData.factors?.user?.loginName}
+        displayName={sessionData.factors?.user?.displayName}
+        showDropdown={false}
       />
+      <div className="w-full">
+        <LoginU2F
+          loginName={loginName}
+          sessionId={sessionId}
+          organization={organization}
+          login={false}
+          redirect="/password/change"
+        />
+      </div>
     </AuthPanel>
   );
 }

--- a/app/(auth)/password/reset/actions.test.ts
+++ b/app/(auth)/password/reset/actions.test.ts
@@ -114,6 +114,15 @@ describe("submitUserNameForm", () => {
     expect(passwordResetWithReturn).not.toHaveBeenCalled();
   });
 
+  it("returns a generic error when user lookup fails", async () => {
+    vi.mocked(listUsers).mockRejectedValue(new Error("HTTP 503"));
+
+    const response = await submitUserNameForm({ loginName: "person@canada.ca" });
+
+    expect(response).toEqual({ error: "translated:errors.couldNotSendResetLink" });
+    expect(passwordResetWithReturn).not.toHaveBeenCalled();
+  });
+
   it("returns a generic error when user has no email", async () => {
     vi.mocked(listUsers).mockResolvedValue({
       details: { totalResult: BigInt(1) },

--- a/app/(auth)/password/reset/actions.ts
+++ b/app/(auth)/password/reset/actions.ts
@@ -31,15 +31,22 @@ export const submitUserNameForm = async (
   const { serviceUrl } = getServiceUrlFromHeaders(_headers);
   const { t } = await serverTranslation("password");
 
+  const genericErrorResponse = {
+    error: t("errors.couldNotSendResetLink"),
+  };
+
   const users = await listUsers({
     serviceUrl,
     loginName: command.loginName,
     organizationId: command.organization,
+  }).catch((_error) => {
+    logMessage.warn("Failed to look up password reset user");
+    return undefined;
   });
 
-  const genericErrorResponse = {
-    error: t("errors.couldNotSendResetLink"),
-  };
+  if (!users) {
+    return genericErrorResponse;
+  }
 
   if (!users.details || users.details.totalResult !== BigInt(1) || !users.result[0].userId) {
     return genericErrorResponse;

--- a/app/(auth)/password/reset/page.tsx
+++ b/app/(auth)/password/reset/page.tsx
@@ -2,14 +2,11 @@
  * Framework and Third-Party
  *--------------------------------------------*/
 import { Metadata } from "next";
-import { headers } from "next/headers";
 
 /*--------------------------------------------*
  * Internal Aliases
  *--------------------------------------------*/
 import { ZITADEL_ORGANIZATION } from "@root/constants/config";
-import { getServiceUrlFromHeaders } from "@lib/service-url";
-import { getPasswordComplexitySettings } from "@lib/zitadel";
 import { serverTranslation } from "@i18n/server";
 import { AuthPanel } from "@components/auth/AuthPanel";
 
@@ -24,13 +21,6 @@ export async function generateMetadata(): Promise<Metadata> {
 
 export default async function Page() {
   const organization = ZITADEL_ORGANIZATION;
-  const _headers = await headers();
-  const { serviceUrl } = getServiceUrlFromHeaders(_headers);
-
-  const passwordComplexitySettings = await getPasswordComplexitySettings({
-    serviceUrl,
-    organization,
-  });
 
   return (
     <AuthPanel
@@ -38,10 +28,7 @@ export default async function Page() {
       descriptionI18nKey="reset.description"
       namespace="password"
     >
-      <PasswordResetFlow
-        passwordComplexitySettings={passwordComplexitySettings}
-        organization={organization}
-      />
+      <PasswordResetFlow organization={organization} />
     </AuthPanel>
   );
 }

--- a/app/(auth)/password/reset/verify/time-based/page.tsx
+++ b/app/(auth)/password/reset/verify/time-based/page.tsx
@@ -18,11 +18,7 @@ import { getSerializableObject } from "@lib/utils";
 import { getLoginSettings } from "@lib/zitadel";
 import { serverTranslation } from "@i18n/server";
 import { AuthPanel } from "@components/auth/AuthPanel";
-
-/*--------------------------------------------*
- * Parent Relative
- *--------------------------------------------*/
-import { LoginOTP } from "../../../../otp/[method]/components/LoginOTP";
+import { LoginOTP } from "@components/mfa/LoginOTP";
 
 export async function generateMetadata(): Promise<Metadata> {
   const { t } = await serverTranslation("otp");

--- a/app/(auth)/register/page.tsx
+++ b/app/(auth)/register/page.tsx
@@ -9,10 +9,8 @@ import { headers } from "next/headers";
  *--------------------------------------------*/
 import { ZITADEL_ORGANIZATION } from "@root/constants/config";
 import { getOriginalHostFromHeaders } from "@lib/server/host";
-import { getServiceUrlFromHeaders } from "@lib/service-url";
 import { resolveSiteConfigByHost } from "@lib/site-config";
 import { SearchParams } from "@lib/utils";
-import { getLegalAndSupportSettings, getPasswordComplexitySettings } from "@lib/zitadel";
 import { serverTranslation } from "@i18n/server";
 import { AuthPanel } from "@components/auth/AuthPanel";
 
@@ -30,32 +28,14 @@ export default async function Page(props: { searchParams: Promise<SearchParams> 
   const searchParams = await props.searchParams;
   const { requestId } = searchParams;
 
-  const _headers = await headers();
-  const { serviceUrl } = getServiceUrlFromHeaders(_headers);
-  const resolvedHost = getOriginalHostFromHeaders(_headers);
+  const resolvedHost = getOriginalHostFromHeaders(await headers());
   const siteConfig = resolveSiteConfigByHost(resolvedHost);
 
   const organization = ZITADEL_ORGANIZATION;
 
-  const legal = await getLegalAndSupportSettings({
-    serviceUrl,
-    organization,
-  });
-
-  const passwordComplexitySettings = await getPasswordComplexitySettings({
-    serviceUrl,
-    organization,
-  });
-
   return (
     <AuthPanel titleI18nKey="title" descriptionI18nKey="description" namespace="register">
-      {legal && passwordComplexitySettings && organization && (
-        <RegisterForm
-          organization={organization}
-          requestId={requestId}
-          siteConfig={siteConfig}
-        ></RegisterForm>
-      )}
+      <RegisterForm organization={organization} requestId={requestId} siteConfig={siteConfig} />
     </AuthPanel>
   );
 }

--- a/app/(auth)/register/password/page.tsx
+++ b/app/(auth)/register/password/page.tsx
@@ -3,13 +3,15 @@
  *--------------------------------------------*/
 import { Metadata } from "next";
 import { headers } from "next/headers";
+import { redirect } from "next/navigation";
 
 /*--------------------------------------------*
  * Internal Aliases
  *--------------------------------------------*/
 import { ZITADEL_ORGANIZATION } from "@root/constants/config";
+import { logMessage } from "@lib/logger";
 import { getServiceUrlFromHeaders } from "@lib/service-url";
-import { getLegalAndSupportSettings, getPasswordComplexitySettings } from "@lib/zitadel";
+import { getPasswordComplexitySettings } from "@lib/zitadel";
 import { serverTranslation } from "@i18n/server";
 import { AuthPanel } from "@components/auth/AuthPanel";
 
@@ -27,16 +29,17 @@ export default async function Page() {
   const { serviceUrl } = getServiceUrlFromHeaders(_headers);
 
   const organization = ZITADEL_ORGANIZATION;
-
-  const legal = await getLegalAndSupportSettings({
-    serviceUrl,
-    organization,
-  });
-
   const passwordComplexitySettings = await getPasswordComplexitySettings({
     serviceUrl,
     organization,
+  }).catch((_error) => {
+    logMessage.warn("Failed to load password complexity settings for registration");
+    return undefined;
   });
+
+  if (!passwordComplexitySettings) {
+    redirect("/register");
+  }
 
   return (
     <AuthPanel
@@ -44,9 +47,7 @@ export default async function Page() {
       descriptionI18nKey="password.description"
       namespace="register"
     >
-      {legal && passwordComplexitySettings && (
-        <PasswordPageClient passwordComplexitySettings={passwordComplexitySettings} />
-      )}
+      <PasswordPageClient passwordComplexitySettings={passwordComplexitySettings} />
     </AuthPanel>
   );
 }

--- a/app/(auth)/u2f/components/ChooseSecondFactor.tsx
+++ b/app/(auth)/u2f/components/ChooseSecondFactor.tsx
@@ -13,12 +13,9 @@ import { AuthenticationMethodType } from "@zitadel/proto/zitadel/user/v2/user_se
 import { buildUrlWithRequestId } from "@lib/utils";
 import { cn } from "@lib/utils";
 import { useTranslation } from "@i18n/client";
+import { MethodOptionCard } from "@components/mfa/MethodOptionCard";
 import { Button } from "@components/ui/button/Button";
 
-/*--------------------------------------------*
- * Local Relative
- *--------------------------------------------*/
-import { MethodOptionCard } from "./MethodOptionCard";
 type Props = {
   loginName?: string;
   sessionId?: string;

--- a/app/(auth)/u2f/page.tsx
+++ b/app/(auth)/u2f/page.tsx
@@ -18,8 +18,7 @@ import { SearchParams } from "@lib/utils";
 import { serverTranslation } from "@i18n/server";
 import { UserAvatar } from "@components/account/user-avatar";
 import { AuthPanel } from "@components/auth/AuthPanel";
-
-import { LoginU2F } from "./components/LoginU2F";
+import { LoginU2F } from "@components/mfa/LoginU2F";
 
 export async function generateMetadata(): Promise<Metadata> {
   const { t } = await serverTranslation("u2f");

--- a/app/(auth)/u2f/set/components/ChooseSecondFactorToSetup.tsx
+++ b/app/(auth)/u2f/set/components/ChooseSecondFactorToSetup.tsx
@@ -12,12 +12,9 @@ import { useRouter } from "next/navigation";
 import { ENABLE_EMAIL_OTP } from "@root/constants/config";
 import { buildUrlWithRequestId } from "@lib/utils";
 import { useTranslation } from "@i18n/client";
+import { MethodOptionCard } from "@components/mfa/MethodOptionCard";
 import { Button } from "@components/ui/button/Button";
 
-/*--------------------------------------------*
- * Local Relative
- *--------------------------------------------*/
-import { MethodOptionCard } from "../../components/MethodOptionCard";
 type Props = {
   checkAfter: boolean;
   requestId?: string;

--- a/app/(auth)/u2f/set/page.tsx
+++ b/app/(auth)/u2f/set/page.tsx
@@ -10,7 +10,11 @@ import { redirect } from "next/navigation";
  *--------------------------------------------*/
 import { getSessionCredentials } from "@lib/cookies";
 import { logMessage } from "@lib/logger";
-import { AuthLevel, checkAuthenticationLevel } from "@lib/server/route-protection";
+import {
+  AuthLevel,
+  checkAuthenticationLevel,
+  requiresStrongMfaSetupVerification,
+} from "@lib/server/route-protection";
 import { getServiceUrlFromHeaders } from "@lib/service-url";
 import { loadSessionById } from "@lib/session";
 import { serverTranslation } from "@i18n/server";
@@ -60,6 +64,13 @@ export default async function Page(props: {
       hasOrganization: !!organization,
     });
     redirect("/mfa/set");
+  }
+
+  if (requiresStrongMfaSetupVerification(sessionFactors)) {
+    logMessage.debug({
+      message: "U2F setup requires strong MFA re-verification",
+    });
+    redirect("/mfa/set/verify");
   }
 
   if (!loginName || !sessionFactors.id) {

--- a/app/(auth)/u2f/set/page.tsx
+++ b/app/(auth)/u2f/set/page.tsx
@@ -10,13 +10,8 @@ import { redirect } from "next/navigation";
  *--------------------------------------------*/
 import { getSessionCredentials } from "@lib/cookies";
 import { logMessage } from "@lib/logger";
-import {
-  AuthLevel,
-  checkAuthenticationLevel,
-  requiresStrongMfaSetupVerification,
-} from "@lib/server/route-protection";
+import { loadMfaSetupSession } from "@lib/server/mfa-setup";
 import { getServiceUrlFromHeaders } from "@lib/service-url";
-import { loadSessionById } from "@lib/session";
 import { serverTranslation } from "@i18n/server";
 import { UserAvatar } from "@components/account/user-avatar";
 import { AuthPanel } from "@components/auth/AuthPanel";
@@ -37,41 +32,25 @@ export default async function Page(props: {
   const _headers = await headers();
   const { serviceUrl } = getServiceUrlFromHeaders(_headers);
 
-  const { sessionId, loginName, organization, requestId } = await getSessionCredentials();
+  let sessionId: string | undefined;
+  let loginName: string | undefined;
+  let organization: string | undefined;
+  let requestId: string | undefined;
 
-  const authCheck = await checkAuthenticationLevel(
+  try {
+    ({ sessionId, loginName, organization, requestId } = await getSessionCredentials());
+  } catch {
+    redirect("/password");
+  }
+
+  const sessionFactors = await loadMfaSetupSession({
     serviceUrl,
-    AuthLevel.PASSWORD_REQUIRED,
+    sessionId,
     loginName,
-    organization
-  );
-
-  if (!authCheck.satisfied) {
-    logMessage.debug({
-      message: "U2F setup page auth check failed",
-      reason: authCheck.reason,
-      redirect: authCheck.redirect,
-    });
-    redirect(authCheck.redirect || "/password");
-  }
-
-  const sessionFactors = await loadSessionById(serviceUrl, sessionId, organization);
-
-  if (!sessionFactors) {
-    logMessage.debug({
-      message: "U2F setup page missing session factors",
-      hasSessionId: !!sessionId,
-      hasOrganization: !!organization,
-    });
-    redirect("/mfa/set");
-  }
-
-  if (requiresStrongMfaSetupVerification(sessionFactors)) {
-    logMessage.debug({
-      message: "U2F setup requires strong MFA re-verification",
-    });
-    redirect("/mfa/set/verify");
-  }
+    organization,
+    pageName: "U2F setup page",
+    missingSessionRedirect: "/mfa/set",
+  });
 
   if (!loginName || !sessionFactors.id) {
     logMessage.debug({

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -19,7 +19,7 @@ export default function Error({ error }: { error: Error & { digest?: string } })
   return (
     <div className="">
       <div className="text-center">
-        <h1 className="mt-8 !mb-6">
+        <h1 className="mt-8 mb-6!">
           <I18n i18nKey="title" namespace="error" />
         </h1>
         <Image
@@ -28,6 +28,7 @@ export default function Error({ error }: { error: Error & { digest?: string } })
           width={200}
           height={200}
           className="mx-auto mb-6"
+          style={{ height: "auto" }}
           priority
         />
       </div>

--- a/components/auth/Logout.tsx
+++ b/components/auth/Logout.tsx
@@ -6,16 +6,21 @@ import { headers } from "next/headers";
 /*--------------------------------------------*
  * Internal Aliases
  *--------------------------------------------*/
+import { logMessage } from "@lib/logger";
 import { loadSessionsFromCookies } from "@lib/server/session";
 import { getServiceUrlFromHeaders } from "@lib/service-url";
 import { isSessionValid } from "@lib/session";
 import { serverTranslation } from "@i18n/server";
 import { LogoutButton } from "@components/auth/LogoutButton";
+
 export const Logout = async ({ className }: { className?: string }) => {
   const _headers = await headers();
   const { serviceUrl } = getServiceUrlFromHeaders(_headers);
   const { t } = await serverTranslation("header");
-  const allSessions = await loadSessionsFromCookies({ serviceUrl });
+  const allSessions = await loadSessionsFromCookies({ serviceUrl }).catch((_error) => {
+    logMessage.warn("Failed to load sessions for logout state");
+    return [];
+  });
 
   // Filter to only fully authenticated sessions (isSessionValid is async)
   const validSessions = await Promise.all(

--- a/components/mfa/LoginOTP.tsx
+++ b/components/mfa/LoginOTP.tsx
@@ -3,12 +3,16 @@
 /*--------------------------------------------*
  * Framework and Third-Party
  *--------------------------------------------*/
-import { useActionState } from "react";
-import { useEffect, useRef, useState } from "react";
+import { useActionState, useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { LoginSettings } from "@zitadel/proto/zitadel/settings/v2/login_settings_pb";
 
+import {
+  FormState,
+  handleOTPFormSubmit,
+  updateSessionForOTPChallenge,
+} from "@root/app/(auth)/otp/[method]/actions";
 /*--------------------------------------------*
  * Internal Aliases
  *--------------------------------------------*/
@@ -23,11 +27,6 @@ import { Alert, ErrorStatus } from "@components/ui/form";
 import { CodeEntry } from "@components/ui/form/CodeEntry";
 import { ErrorSummary } from "@components/ui/form/ErrorSummary";
 
-/*--------------------------------------------*
- * Local Relative
- *--------------------------------------------*/
-import { FormState, handleOTPFormSubmit, updateSessionForOTPChallenge } from "../actions";
-
 export function LoginOTP({
   loginName,
   sessionId,
@@ -40,7 +39,7 @@ export function LoginOTP({
   redirect,
   displayName,
 }: {
-  loginName?: string; // either loginName or sessionId must be provided
+  loginName?: string;
   sessionId?: string;
   requestId?: string;
   organization?: string;
@@ -87,8 +86,8 @@ export function LoginOTP({
   }, []);
 
   const localFormAction = async (_: FormState, formData?: FormData) => {
-    const code = (formData?.get("code") as string) ?? "";
-    const result = await handleOTPFormSubmit(code, {
+    const enteredCode = (formData?.get("code") as string) ?? "";
+    const result = await handleOTPFormSubmit(enteredCode, {
       loginName,
       sessionId,
       organization,

--- a/components/mfa/LoginU2F.tsx
+++ b/components/mfa/LoginU2F.tsx
@@ -12,6 +12,7 @@ import {
 } from "@zitadel/proto/zitadel/session/v2/challenge_pb";
 import { Checks } from "@zitadel/proto/zitadel/session/v2/session_service_pb";
 
+import { verifyU2FLogin } from "@root/app/(auth)/u2f/actions";
 /*--------------------------------------------*
  * Internal Aliases
  *--------------------------------------------*/
@@ -19,11 +20,6 @@ import { updateSession } from "@lib/server/session";
 import { coerceToArrayBuffer, coerceToBase64Url } from "@lib/utils/base64";
 import { useTranslation } from "@i18n";
 import { Alert, ErrorStatus } from "@components/ui/form";
-
-/*--------------------------------------------*
- * Parent Relative
- *--------------------------------------------*/
-import { verifyU2FLogin } from "../actions";
 
 type PublicKeyCredentialRequestOptionsData = {
   challenge: BufferSource | string;
@@ -34,7 +30,6 @@ type PublicKeyCredentialRequestOptionsData = {
   [key: string]: unknown;
 };
 
-// either loginName or sessionId must be provided
 type Props = {
   loginName?: string;
   sessionId?: string;
@@ -54,7 +49,6 @@ async function getCredentialAssertionData(
       (listItem: PublicKeyCredentialDescriptor) => ({
         ...listItem,
         id: coerceToArrayBuffer(listItem.id, "publicKey.allowCredentials.id"),
-        // Only allow hardware key transports (USB, NFC, BLE) - excludes platform/internal transports
         transports: ["usb", "ble", "nfc"] as AuthenticatorTransport[],
       })
     ),
@@ -170,7 +164,6 @@ export function LoginU2F({
       return router.push(response.redirect);
     }
 
-    // If we got here, something went wrong - no redirect or error was returned
     if (!response) {
       setError(t("verify.errors.noResponseReceived"));
     } else {

--- a/components/mfa/MethodOptionCard.tsx
+++ b/components/mfa/MethodOptionCard.tsx
@@ -10,6 +10,7 @@ import Image from "next/image";
  *--------------------------------------------*/
 import { getImageUrl } from "@lib/imageUrl";
 import { cn } from "@lib/utils";
+
 type Props = {
   method: string;
   title: string;
@@ -63,7 +64,7 @@ export function MethodOptionCard({
               {isDefault && (
                 <>
                   {" "}
-                  — <span className="italic">{defaultText}</span>
+                  <span className="italic">{defaultText}</span>
                 </>
               )}
             </div>

--- a/components/mfa/StrongFactorSelection.tsx
+++ b/components/mfa/StrongFactorSelection.tsx
@@ -13,16 +13,18 @@ import { useTranslation } from "@i18n/client";
 import { Button } from "@components/ui/button/Button";
 
 /*--------------------------------------------*
- * Parent Relative
+ * Local Relative
  *--------------------------------------------*/
-import { MethodOptionCard } from "../../../../u2f/components/MethodOptionCard";
+import { MethodOptionCard } from "./MethodOptionCard";
 
 type Props = {
   canUseTotp: boolean;
   canUseU2F: boolean;
+  totpUrl: string;
+  u2fUrl: string;
 };
 
-export function PasswordResetSecondFactor({ canUseTotp, canUseU2F }: Props) {
+export function StrongFactorSelection({ canUseTotp, canUseU2F, totpUrl, u2fUrl }: Props) {
   const router = useRouter();
   const { t } = useTranslation("mfa");
   const [selectedMethod, setSelectedMethod] = useState<string | null>(null);
@@ -42,7 +44,7 @@ export function PasswordResetSecondFactor({ canUseTotp, canUseU2F }: Props) {
             title={t("set.authenticator.title")}
             icon="/img/verified_user_24px.png"
             description={t("set.authenticator.description")}
-            url="/password/reset/verify/time-based"
+            url={totpUrl}
             isSelected={selectedMethod === "authenticator"}
             onSelect={handleMethodSelect}
           />
@@ -53,7 +55,7 @@ export function PasswordResetSecondFactor({ canUseTotp, canUseU2F }: Props) {
             title={t("set.securityKey.title")}
             icon="/img/fingerprint_24px.png"
             description={t("set.securityKey.description")}
-            url="/password/reset/verify/u2f"
+            url={u2fUrl}
             isSelected={selectedMethod === "securityKey"}
             onSelect={handleMethodSelect}
           />

--- a/components/ui/toast/Toast.tsx
+++ b/components/ui/toast/Toast.tsx
@@ -20,27 +20,27 @@ import { WarningIcon } from "@components/icons/WarningIcon";
 
 const contextClass = {
   success: {
-    classes: "bg-green-50 text-green-800 [&_svg]:fill-green-800",
+    classes: "gc-toast gc-toast--success",
     icon: <CircleCheckIcon className="fill-green-800 my-2 mr-2 size-6" />,
   },
   error: {
-    classes: "bg-red-100 text-red-800 [&_svg]:fill-red-800",
+    classes: "gc-toast gc-toast--error",
     icon: <WarningIcon className="my-2 mr-2 size-6 fill-red-800" />,
   },
   info: {
-    classes: "bg-blue-50 text-blue-600 [&_svg]:fill-blue-600",
+    classes: "gc-toast gc-toast--info",
     icon: <InfoIcon className="my-2 mr-2 size-6 fill-blue-600" />,
   },
   warn: {
-    classes: "bg-yellow-50 text-yellow-700 [&_svg]:fill-yellow-700",
+    classes: "gc-toast gc-toast--warn",
     icon: <WarningIcon className="my-2 mr-2 size-6 fill-yellow-700" />,
   },
   warning: {
-    classes: "bg-yellow-50 text-yellow-700 [&_svg]:fill-yellow-700",
+    classes: "gc-toast gc-toast--warning",
     icon: <WarningIcon className="my-2 mr-2 size-6 fill-yellow-700" />,
   },
   default: {
-    classes: "bg-white text-black [&_svg]:fill-black",
+    classes: "gc-toast gc-toast--default",
     icon: <InfoIcon className="my-2 mr-2 size-6 fill-black" />,
   },
 };
@@ -71,7 +71,7 @@ export const ToastContainer = ({
     <OriginalContainer
       containerId={containerId}
       toastClassName={(context?: ToastContext) => {
-        return `${contextClass[context?.type || "default"]["classes"]} 
+        return `${context?.defaultClassName || ""} ${contextClass[context?.type || "default"]["classes"]} 
         relative drop-shadow-md p-1 rounded-md justify-between overflow-hidden p-4 cursor-pointer text-base`;
       }}
       style={{ width: width }}

--- a/lib/server/mfa-setup.ts
+++ b/lib/server/mfa-setup.ts
@@ -1,0 +1,69 @@
+import { redirect } from "next/navigation";
+
+import { logMessage } from "@lib/logger";
+import { loadSessionById, loadSessionByLoginname, type SessionWithAuthData } from "@lib/session";
+
+import {
+  AuthLevel,
+  checkAuthenticationLevel,
+  requiresStrongMfaSetupVerification,
+} from "./route-protection";
+
+type LoadMfaSetupSessionParams = {
+  serviceUrl: string;
+  sessionId?: string;
+  loginName?: string;
+  organization?: string;
+  pageName: string;
+  missingSessionRedirect: string;
+};
+
+export async function loadMfaSetupSession({
+  serviceUrl,
+  sessionId,
+  loginName,
+  organization,
+  pageName,
+  missingSessionRedirect,
+}: LoadMfaSetupSessionParams): Promise<SessionWithAuthData> {
+  const authCheck = await checkAuthenticationLevel(
+    serviceUrl,
+    AuthLevel.PASSWORD_REQUIRED,
+    loginName,
+    organization
+  );
+
+  if (!authCheck.satisfied) {
+    logMessage.debug({
+      message: `${pageName} auth check failed`,
+      reason: authCheck.reason,
+      redirect: authCheck.redirect,
+    });
+    redirect(authCheck.redirect || "/password");
+  }
+
+  let sessionData: SessionWithAuthData;
+
+  try {
+    sessionData = sessionId
+      ? await loadSessionById(serviceUrl, sessionId, organization)
+      : await loadSessionByLoginname(serviceUrl, loginName, organization);
+  } catch {
+    logMessage.debug({
+      message: `${pageName} missing session factors`,
+      hasSessionId: !!sessionId,
+      hasLoginName: !!loginName,
+      hasOrganization: !!organization,
+    });
+    redirect(missingSessionRedirect);
+  }
+
+  if (requiresStrongMfaSetupVerification(sessionData)) {
+    logMessage.debug({
+      message: `${pageName} requires strong MFA re-verification`,
+    });
+    redirect("/mfa/set/verify");
+  }
+
+  return sessionData;
+}

--- a/lib/server/mfa-verify.ts
+++ b/lib/server/mfa-verify.ts
@@ -1,0 +1,75 @@
+import { redirect } from "next/navigation";
+
+import { getSessionCredentials } from "@lib/cookies";
+import { logMessage } from "@lib/logger";
+import { loadSessionById, loadSessionByLoginname, type SessionWithAuthData } from "@lib/session";
+
+import { AuthLevel, checkAuthenticationLevel } from "./route-protection";
+
+type LoadMfaVerificationSessionParams = {
+  serviceUrl: string;
+  pageName: string;
+  missingSessionRedirect: string;
+};
+
+type MfaVerificationSession = {
+  sessionId?: string;
+  loginName?: string;
+  organization?: string;
+  sessionData: SessionWithAuthData;
+};
+
+export async function loadMfaVerificationSession({
+  serviceUrl,
+  pageName,
+  missingSessionRedirect,
+}: LoadMfaVerificationSessionParams): Promise<MfaVerificationSession> {
+  let sessionId: string | undefined;
+  let loginName: string | undefined;
+  let organization: string | undefined;
+
+  try {
+    ({ sessionId, loginName, organization } = await getSessionCredentials());
+  } catch {
+    redirect("/password");
+  }
+
+  const authCheck = await checkAuthenticationLevel(
+    serviceUrl,
+    AuthLevel.PASSWORD_REQUIRED,
+    loginName,
+    organization
+  );
+
+  if (!authCheck.satisfied) {
+    logMessage.debug({
+      message: `${pageName} auth check failed`,
+      reason: authCheck.reason,
+      redirect: authCheck.redirect,
+    });
+    redirect(authCheck.redirect || "/password");
+  }
+
+  let sessionData: SessionWithAuthData;
+
+  try {
+    sessionData = sessionId
+      ? await loadSessionById(serviceUrl, sessionId, organization)
+      : await loadSessionByLoginname(serviceUrl, loginName, organization);
+  } catch {
+    logMessage.debug({
+      message: `${pageName} missing session factors`,
+      hasSessionId: !!sessionId,
+      hasLoginName: !!loginName,
+      hasOrganization: !!organization,
+    });
+    redirect(missingSessionRedirect);
+  }
+
+  return {
+    sessionId,
+    loginName,
+    organization,
+    sessionData,
+  };
+}

--- a/lib/server/route-protection.test.ts
+++ b/lib/server/route-protection.test.ts
@@ -1,4 +1,5 @@
 import { timestampDate } from "@zitadel/client";
+import { AuthenticationMethodType } from "@zitadel/proto/zitadel/user/v2/user_service_pb";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { loadMostRecentSession } from "@lib/session";
@@ -10,6 +11,7 @@ import {
   getSmartRedirect,
   hasAnyMFA,
   hasStrongMFA,
+  requiresStrongMfaSetupVerification,
 } from "./route-protection";
 
 vi.mock("@zitadel/client", () => ({
@@ -54,6 +56,39 @@ describe("route-protection", () => {
 
     expect(hasAnyMFA(otpEmailSession)).toBe(true);
     expect(hasStrongMFA(otpEmailSession)).toBe(false);
+  });
+
+  it("requires strong MFA re-verification before MFA setup when a strong method is configured", () => {
+    expect(
+      requiresStrongMfaSetupVerification({
+        authMethods: [AuthenticationMethodType.TOTP],
+        factors: {
+          user: { id: "user-123" },
+          password: { verifiedAt: {} },
+        },
+      } as never)
+    ).toBe(true);
+
+    expect(
+      requiresStrongMfaSetupVerification({
+        authMethods: [AuthenticationMethodType.TOTP],
+        factors: {
+          user: { id: "user-123" },
+          password: { verifiedAt: {} },
+          totp: { verifiedAt: {} },
+        },
+      } as never)
+    ).toBe(false);
+
+    expect(
+      requiresStrongMfaSetupVerification({
+        authMethods: [],
+        factors: {
+          user: { id: "user-123" },
+          password: { verifiedAt: {} },
+        },
+      } as never)
+    ).toBe(false);
   });
 
   it("allows open routes without loading session", async () => {

--- a/lib/server/route-protection.ts
+++ b/lib/server/route-protection.ts
@@ -3,6 +3,7 @@
  *--------------------------------------------*/
 import { timestampDate } from "@zitadel/client";
 import { Session } from "@zitadel/proto/zitadel/session/v2/session_pb";
+import { AuthenticationMethodType } from "@zitadel/proto/zitadel/user/v2/user_service_pb";
 
 /*--------------------------------------------*
  * Internal Aliases
@@ -111,6 +112,37 @@ export function hasAnyMFA(session: Session | null): boolean {
   if (!session) return false;
   const factors = checkSessionFactors(session);
   return factors.totpVerified || factors.u2fVerified || factors.otpEmailVerified;
+}
+
+type SetupProtectionSession = {
+  authMethods?: AuthenticationMethodType[];
+  factors?: Session["factors"];
+};
+
+/**
+ * Users who already configured a strong MFA factor must re-verify it before adding more MFA methods.
+ */
+export function requiresStrongMfaSetupVerification(
+  session: SetupProtectionSession | null | undefined
+): boolean {
+  if (!session) {
+    return false;
+  }
+
+  const hasConfiguredStrongMFA =
+    session.authMethods?.some(
+      (method) =>
+        method === AuthenticationMethodType.TOTP || method === AuthenticationMethodType.U2F
+    ) ?? false;
+
+  if (!hasConfiguredStrongMFA) {
+    return false;
+  }
+
+  const hasVerifiedStrongMFA =
+    !!session.factors?.totp?.verifiedAt || !!session.factors?.webAuthN?.verifiedAt;
+
+  return !hasVerifiedStrongMFA;
 }
 
 /**

--- a/lib/session.ts
+++ b/lib/session.ts
@@ -59,7 +59,7 @@ export async function loadMostRecentSession({
   }).then((resp: GetSessionResponse) => resp.session);
 }
 
-type SessionWithAuthData = {
+export type SessionWithAuthData = {
   id?: string;
   factors?: Session["factors"];
   authMethods: AuthenticationMethodType[];

--- a/proxy.ts
+++ b/proxy.ts
@@ -15,8 +15,10 @@ import {
   AuthLevel,
   checkAuthenticationLevel,
   getSmartRedirect,
+  requiresStrongMfaSetupVerification,
 } from "./lib/server/route-protection";
 import { getServiceUrlFromHeaders } from "./lib/service-url";
+import { loadSessionById } from "./lib/session";
 
 export const config = {
   matcher: [
@@ -52,6 +54,19 @@ async function loadSecuritySettings(request: NextRequest): Promise<SecuritySetti
   }
 
   return response.settings;
+}
+
+function isMfaSetupRoute(pathname: string): boolean {
+  return (
+    pathname === "/mfa/set" ||
+    pathname.startsWith("/mfa/set/") ||
+    pathname === "/u2f/set" ||
+    pathname.startsWith("/u2f/set/") ||
+    pathname === "/otp/email/set" ||
+    pathname.startsWith("/otp/email/set/") ||
+    pathname === "/otp/time-based/set" ||
+    pathname.startsWith("/otp/time-based/set/")
+  );
 }
 
 export async function proxy(request: NextRequest) {
@@ -163,6 +178,24 @@ export async function proxy(request: NextRequest) {
       const hasPassword = session?.factors?.password?.verifiedAt;
 
       if (hasPassword) {
+        if (isMfaSetupRoute(pathname) && session?.id) {
+          try {
+            const setupSession = await loadSessionById(
+              serviceUrl,
+              session.id,
+              ZITADEL_ORGANIZATION
+            );
+
+            if (requiresStrongMfaSetupVerification(setupSession)) {
+              const verifyUrl = request.nextUrl.clone();
+              verifyUrl.pathname = "/mfa/set/verify";
+              return NextResponse.redirect(verifyUrl);
+            }
+          } catch {
+            // Let the page-level guard handle failures fetching the enriched session.
+          }
+        }
+
         // Allow access to MFA flow pages when password is already verified
         return NextResponse.next({
           request: { headers: requestHeaders },

--- a/styles/app.css
+++ b/styles/app.css
@@ -7,6 +7,44 @@
 @import "@gcforms/core/styles/gc-header.css";
 @import "react-toastify/dist/ReactToastify.css";
 
+.Toastify__toast.gc-toast {
+  color: inherit;
+}
+
+.Toastify__toast.gc-toast svg {
+  fill: currentColor;
+}
+
+.Toastify__toast.gc-toast--success,
+.Toastify__toast.Toastify__toast--success {
+  background: var(--color-gcds-green-50) !important;
+  color: var(--color-gcds-green-800) !important;
+}
+
+.Toastify__toast.gc-toast--error,
+.Toastify__toast.Toastify__toast--error {
+  background: var(--color-gcds-red-100) !important;
+  color: var(--color-gcds-red-800) !important;
+}
+
+.Toastify__toast.gc-toast--info,
+.Toastify__toast.Toastify__toast--info {
+  background: var(--color-gcds-blue-50) !important;
+  color: var(--color-gcds-blue-800) !important;
+}
+
+.Toastify__toast.gc-toast--warn,
+.Toastify__toast.gc-toast--warning,
+.Toastify__toast.Toastify__toast--warning {
+  background: var(--color-gcds-yellow-50) !important;
+  color: var(--color-gcds-yellow-800) !important;
+}
+
+.Toastify__toast.gc-toast--default {
+  background: var(--color-white-default) !important;
+  color: var(--color-black-default) !important;
+}
+
 @custom-variant xxl (@media (max-width: 1200px));
 @custom-variant xl (@media (max-width: 992px));
 @custom-variant lg (@media (max-width: 768px));


### PR DESCRIPTION
# Summary | Résumé

- Adds a strong MFA verify step for change password and add MFA page.
- Adds guard for direct access to `/set`

This ensures when logging in with email as the second factor a strong MFA is needed before adding new strong MFA and also in front of change password.