### PR TITLE
fix: CSP failures for styles

### DIFF
--- a/app/(auth)/all-set/page.tsx
+++ b/app/(auth)/all-set/page.tsx
@@ -52,6 +52,7 @@ export default async function Page(props: { searchParams: Promise<SearchParams> 
               width={352}
               height={261}
               className="h-auto w-full max-w-[250px]"
+              style={{ color: "" }}
             />
           </div>
 

--- a/app/(auth)/error.tsx
+++ b/app/(auth)/error.tsx
@@ -27,8 +27,8 @@ export default function Error({ error }: { error: Error & { digest?: string } })
           alt="Goose"
           width={200}
           height={200}
-          className="mx-auto mb-6"
-          style={{ height: "auto" }}
+          className="mx-auto mb-6 h-auto"
+          style={{ color: "" }}
           priority
         />
       </div>

--- a/app/(auth)/verify/success/page.tsx
+++ b/app/(auth)/verify/success/page.tsx
@@ -29,6 +29,7 @@ export default async function Page(props: { searchParams: Promise<SearchParams> 
           width={704 / 2}
           height={522 / 2}
           className="mx-auto mb-4"
+          style={{ color: "" }}
         />
 
         <LinkButton.Primary href={buildUrlWithRequestId("/mfa/set", requestId)} className="mt-10">

--- a/app/account/components/MFAAuthentication.tsx
+++ b/app/account/components/MFAAuthentication.tsx
@@ -83,6 +83,7 @@ export const MFAAuthentication = ({
                             width={32}
                             height={32}
                             className="inline-block"
+                            style={{ color: "" }}
                           />
                           <div id={id} className="flex items-center gap-1">
                             <span className="font-semibold">
@@ -110,6 +111,7 @@ export const MFAAuthentication = ({
                       width={32}
                       height={32}
                       className="inline-block"
+                      style={{ color: "" }}
                     />
                     <span className="font-semibold">{t("mfaAuthentication.authenticatorApp")}</span>
                     <span>&#8226;</span>
@@ -127,7 +129,7 @@ export const MFAAuthentication = ({
                 width={24}
                 height={24}
                 className="mr-1"
-                style={{ width: "24px", height: "24px" }}
+                style={{ color: "" }}
               />{" "}
               <Link href="/mfa/set">{t("mfaAuthentication.addlMethods")}</Link>
             </div>

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -27,8 +27,8 @@ export default function Error({ error }: { error: Error & { digest?: string } })
           alt="Goose"
           width={200}
           height={200}
-          className="mx-auto mb-6"
-          style={{ height: "auto" }}
+          className="mx-auto mb-6 h-auto"
+          style={{ color: "" }}
           priority
         />
       </div>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@
  *--------------------------------------------*/
 import { Viewport } from "next";
 import { Lato, Noto_Sans } from "next/font/google";
+import { headers } from "next/headers";
 import { dir } from "i18next";
 
 /*--------------------------------------------*
@@ -34,9 +35,13 @@ export const viewport: Viewport = {
 };
 
 export default async function Layout({ children }: { children: React.ReactNode }) {
-  const {
-    i18n: { language },
-  } = await serverTranslation(["fip"]);
+  const [
+    {
+      i18n: { language },
+    },
+    requestHeaders,
+  ] = await Promise.all([serverTranslation(["fip"]), headers()]);
+  const nonce = requestHeaders.get("x-nonce") ?? undefined;
 
   return (
     <html lang={language} dir={dir(language)} className={`${notoSans.variable} ${lato.variable}`}>
@@ -50,7 +55,7 @@ export default async function Layout({ children }: { children: React.ReactNode }
           sizes="32x32"
         />
         {process.env.NEXT_PUBLIC_BASE_PATH && (
-          <style>
+          <style nonce={nonce}>
             {`@font-face {
   font-family: "gcds-icons";
   src: url("${process.env.NEXT_PUBLIC_BASE_PATH}/fonts/icons/gcds-icons.eot");

--- a/components/account/user-avatar/Avatar.tsx
+++ b/components/account/user-avatar/Avatar.tsx
@@ -67,6 +67,7 @@ export function Avatar({ size = "base", name, loginName, imageUrl, shadow }: Ava
           alt="avatar"
           className="size-full rounded-lg border"
           src={imageUrl}
+          style={{ color: "" }}
         />
       ) : (
         <span className={cn("uppercase", size === "large" ? "text-xl" : "text-13px")}>

--- a/components/auth/AuthPanel.tsx
+++ b/components/auth/AuthPanel.tsx
@@ -38,7 +38,7 @@ export const AuthPanel = ({
     <div id={wide ? "auth-panel-wide" : "auth-panel"}>
       {imageSrc && (
         <div className="mb-6 flex justify-center">
-          <Image src={getImageUrl(imageSrc)} alt="" width={125} height={96} />
+          <Image src={getImageUrl(imageSrc)} alt="" width={125} height={96} style={{ color: "" }} />
         </div>
       )}
 

--- a/components/layout/site-header/SiteHeader.tsx
+++ b/components/layout/site-header/SiteHeader.tsx
@@ -3,7 +3,6 @@
 /*--------------------------------------------*
  * Internal Aliases
  *--------------------------------------------*/
-import { cn } from "@lib/utils";
 import { SkipLink } from "@components/ui/skip-link/SkipLink";
 
 /*--------------------------------------------*
@@ -21,17 +20,12 @@ export const SiteHeader = ({
   return (
     <>
       {skipLink && <SkipLink />}
-      <header className={cn("mb-5 border-b-1 border-gray-500 bg-white")}>
-        <div
-          className="mx-auto grid max-w-[71.25rem] grid-cols-[auto_1fr] items-center gap-4 px-4 py-2 laptop:px-0"
-          style={{ gridTemplateAreas: '"logo links"' }}
-        >
-          <div style={{ gridArea: "logo" }}>
+      <header className="mb-5 border-b-1 border-gray-500 bg-white">
+        <div className="mx-auto grid max-w-[71.25rem] grid-cols-[auto_1fr] items-center gap-4 px-4 py-2 [grid-template-areas:'logo_links'] laptop:px-0">
+          <div className="[grid-area:logo]">
             <SiteLink href="/" />
           </div>
-          <div style={{ gridArea: "links" }} className="flex items-center justify-end gap-4">
-            {children}
-          </div>
+          <div className="flex items-center justify-end gap-4 [grid-area:links]">{children}</div>
         </div>
       </header>
     </>

--- a/components/mfa/MethodOptionCard.tsx
+++ b/components/mfa/MethodOptionCard.tsx
@@ -57,7 +57,14 @@ export function MethodOptionCard({
     >
       <div className="flex items-start justify-between gap-4">
         <div className="flex items-start gap-4">
-          <Image src={getImageUrl(icon)} alt={title} width={32} height={32} className="mt-1" />
+          <Image
+            src={getImageUrl(icon)}
+            alt={title}
+            width={32}
+            height={32}
+            className="mt-1"
+            style={{ color: "" }}
+          />
           <div>
             <div className="font-bold">
               {title}
@@ -72,7 +79,13 @@ export function MethodOptionCard({
           </div>
         </div>
         {isSelected && (
-          <Image src={getImageUrl("/img/check_24px.png")} alt="Selected" width={24} height={24} />
+          <Image
+            src={getImageUrl("/img/check_24px.png")}
+            alt="Selected"
+            width={24}
+            height={24}
+            style={{ color: "" }}
+          />
         )}
       </div>
     </div>

--- a/components/ui/toast/Toast.tsx
+++ b/components/ui/toast/Toast.tsx
@@ -56,13 +56,11 @@ type ToastContext = {
 
 export const ToastContainer = ({
   autoClose = 3000,
-  width = "",
   containerId = "",
   limit,
   ariaLabel,
 }: {
   autoClose?: number | false | undefined;
-  width?: string;
   containerId?: string;
   limit?: number;
   ariaLabel?: string;
@@ -74,7 +72,6 @@ export const ToastContainer = ({
         return `${context?.defaultClassName || ""} ${contextClass[context?.type || "default"]["classes"]} 
         relative drop-shadow-md p-1 rounded-md justify-between overflow-hidden p-4 cursor-pointer text-base`;
       }}
-      style={{ width: width }}
       position="top-center"
       autoClose={autoClose}
       hideProgressBar={true}


### PR DESCRIPTION
# Summary
Add the generated nonce to the GCDS icons style tag of the layout.

Remove Next.js automatic `style=color:transparent` attribute from all `<img>` tags by setting an empty colour attribute on the `<Image>` component.

This change also removes all other uses of inline `style` attributes and replaces them with CSS classes as needed.

# Related
- https://github.com/vercel/next.js/issues/45184#issuecomment-2218415129
- #166 