### PR TITLE
chore: stop pushing latest image

### DIFF
--- a/.github/workflows/docker-build-staging.yml
+++ b/.github/workflows/docker-build-staging.yml
@@ -55,5 +55,4 @@ jobs:
           --platform linux/arm64 \
           --build-arg GIT_SHA=$GITHUB_SHA \
           -t "${{ env.REGISTRY_PREFIX }}/idp-login:sha-$GITHUB_SHA" \
-          -t "${{ env.REGISTRY_PREFIX }}/idp-login:latest" \
           .


### PR DESCRIPTION
# Summary
Update the Docker build to only push a commit SHA tagged Docker image. This is being done to support the ECRs switching to `IMMUTABLE`.

# Related
- https://github.com/cds-snc/platform-unified-accounts-user-portal/issues/265
- https://github.com/cds-snc/platform-unified-accounts/pull/87
