### PR TITLE
fix: use consistent logging framework

### DIFF
--- a/app/(auth)/register/actions.ts
+++ b/app/(auth)/register/actions.ts
@@ -62,6 +62,7 @@ export async function registerUser(command: RegisterUserCommand) {
   });
 
   if (!addResponse) {
+    logMessage.error("Failed to create user account during registration");
     return { error: t("errors.couldNotCreateUser") };
   }
 
@@ -82,6 +83,7 @@ export async function registerUser(command: RegisterUserCommand) {
   });
 
   if (!session || !session.factors?.user) {
+    logMessage.error("Failed to create session after registration");
     return { error: t("errors.couldNotCreateSession") };
   }
 
@@ -91,6 +93,7 @@ export async function registerUser(command: RegisterUserCommand) {
   });
 
   if (!userResponse.user) {
+    logMessage.error("Failed to fetch user after registration");
     return { error: t("errors.userNotFound") };
   }
 
@@ -108,6 +111,7 @@ export async function registerUser(command: RegisterUserCommand) {
     return emailVerificationCheck;
   }
 
+  logMessage.info("User registered successfully");
   return completeFlowOrGetUrl(
     command.requestId && session.id
       ? {

--- a/app/account/actions.ts
+++ b/app/account/actions.ts
@@ -34,9 +34,7 @@ export async function removeU2FAction(userId: string, u2fId: string) {
     revalidatePath("/account");
     return { success: true };
   } catch (error) {
-    logMessage.error(
-      `Failed to remove U2F: ${error instanceof Error ? error.message : String(error)}`
-    );
+    logMessage.error("Failed to remove U2F", error);
     return { error: error instanceof Error ? error.message : "Failed to remove security key" };
   }
 }
@@ -58,9 +56,7 @@ export async function removeTOTPAction(userId: string) {
     revalidatePath("/account");
     return { success: true };
   } catch (error) {
-    logMessage.error(
-      `Failed to remove TOTP: ${error instanceof Error ? error.message : String(error)}`
-    );
+    logMessage.error("Failed to remove TOTP", error);
     return { error: "Failed to remove Authentication method" };
   }
 }
@@ -90,9 +86,7 @@ export async function updatePersonalDetailsAction({
     revalidatePath("/account");
     return { success: true };
   } catch (error) {
-    logMessage.error(
-      `Failed to update account: ${error instanceof Error ? error.message : String(error)}`
-    );
+    logMessage.error("Failed to update account", error);
     return { error: "Failed to update account" };
   }
 }

--- a/app/account/components/VerifiedAccount.tsx
+++ b/app/account/components/VerifiedAccount.tsx
@@ -42,9 +42,7 @@ export const VerifiedAccount = ({
         throw new Error(result.error);
       }
     } catch (error) {
-      logMessage.info(
-        `Failed to log out user when redirecting to registration. Errors: ${JSON.stringify(error)}`
-      );
+      logMessage.error("Failed to logout user when redirecting to registration", error);
     }
   };
 

--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -86,9 +86,7 @@ export default async function Page(props: { searchParams: Promise<SearchParams> 
       redirect(loginRedirect);
     }
   } catch (error) {
-    logMessage.error(
-      `Error validating session, redirecting to login. Errors: ${JSON.stringify(error)}`
-    );
+    logMessage.error("Error validating session, redirecting to login", error);
     redirect(loginRedirect);
   }
 

--- a/lib/actions/authenticated.ts
+++ b/lib/actions/authenticated.ts
@@ -49,7 +49,7 @@ export const AuthenticatedAction = <Input extends unknown[], Return>(
       const credentials = await getSessionCredentials();
       return await action(credentials, ...args);
     } catch (error) {
-      logMessage.error("AuthenticatedAction failure", error);
+      logMessage.error(`AuthenticatedAction failure in ${action.name || "unknown"}`, error);
       return { error: "Unauthorized" };
     }
   };

--- a/lib/actions/authenticated.ts
+++ b/lib/actions/authenticated.ts
@@ -49,8 +49,7 @@ export const AuthenticatedAction = <Input extends unknown[], Return>(
       const credentials = await getSessionCredentials();
       return await action(credentials, ...args);
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : "Authentication failed";
-      logMessage.error(`AuthenticatedAction error: ${errorMessage}`);
+      logMessage.error("AuthenticatedAction failure", error);
       return { error: "Unauthorized" };
     }
   };

--- a/lib/logger.test.ts
+++ b/lib/logger.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("pino", () => {
+  const mockPinoInstance = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+  return { default: vi.fn(() => mockPinoInstance) };
+});
+
+import pino from "pino";
+
+import { logMessage } from "./logger";
+
+const mockPinoInstance = pino() as unknown as {
+  debug: ReturnType<typeof vi.fn>;
+  info: ReturnType<typeof vi.fn>;
+  warn: ReturnType<typeof vi.fn>;
+  error: ReturnType<typeof vi.fn>;
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("logMessage.debug", () => {
+  it("logs a string message", () => {
+    logMessage.debug("debug message");
+    expect(mockPinoInstance.debug).toHaveBeenCalledWith("debug message");
+  });
+
+  it("logs a Record object", () => {
+    logMessage.debug({ userId: "123", action: "login" });
+    expect(mockPinoInstance.debug).toHaveBeenCalledWith({ userId: "123", action: "login" });
+  });
+});
+
+describe("logMessage.info", () => {
+  it("logs a string message", () => {
+    logMessage.info("info message");
+    expect(mockPinoInstance.info).toHaveBeenCalledWith("info message");
+  });
+});
+
+describe("logMessage.warn", () => {
+  it("logs a string message", () => {
+    logMessage.warn("warn message");
+    expect(mockPinoInstance.warn).toHaveBeenCalledWith("warn message");
+  });
+});
+
+describe("logMessage.error", () => {
+  it("logs an Error object with err serialization and message as msg", () => {
+    const error = new Error("something went wrong");
+    logMessage.error(error);
+    expect(mockPinoInstance.error).toHaveBeenCalledWith({ err: error }, "something went wrong");
+  });
+
+  it("preserves stack trace via the err object", () => {
+    const error = new Error("oops");
+    logMessage.error(error);
+    const call = mockPinoInstance.error.mock.calls[0];
+    expect(call[0]).toEqual({ err: error });
+    expect(call[0].err.stack).toContain("oops");
+  });
+
+  it("logs a string error directly", () => {
+    logMessage.error("plain error string");
+    expect(mockPinoInstance.error).toHaveBeenCalledWith("plain error string");
+  });
+
+  it("serializes unknown non-string values as JSON", () => {
+    logMessage.error({ code: 404, detail: "not found" });
+    expect(mockPinoInstance.error).toHaveBeenCalledWith(
+      JSON.stringify({ code: 404, detail: "not found" })
+    );
+  });
+
+  it("falls back gracefully when JSON.stringify throws", () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    logMessage.error(circular);
+    const call = mockPinoInstance.error.mock.calls[0][0] as string;
+    expect(call).toContain("Failed to serialize error payload");
+    expect(call).toContain("[Object]");
+    expect(call).toContain("[object Object]");
+  });
+
+  it("logs Error subclass instances with the err object", () => {
+    class CustomError extends Error {
+      code = 7;
+    }
+    const error = new CustomError("connect error");
+    logMessage.error(error);
+    expect(mockPinoInstance.error).toHaveBeenCalledWith({ err: error }, "connect error");
+  });
+});

--- a/lib/logger.test.ts
+++ b/lib/logger.test.ts
@@ -52,36 +52,45 @@ describe("logMessage.warn", () => {
 });
 
 describe("logMessage.error", () => {
-  it("logs an Error object with err serialization and message as msg", () => {
+  it("logs message string alone when no cause provided", () => {
+    logMessage.error("Could not load session");
+    expect(mockPinoInstance.error).toHaveBeenCalledWith("Could not load session");
+  });
+
+  it("logs an Error cause with err serialization and message as msg", () => {
     const error = new Error("something went wrong");
-    logMessage.error(error);
-    expect(mockPinoInstance.error).toHaveBeenCalledWith({ err: error }, "something went wrong");
+    logMessage.error("Failed to get user abc123", error);
+    expect(mockPinoInstance.error).toHaveBeenCalledWith(
+      { err: error },
+      "Failed to get user abc123"
+    );
   });
 
   it("preserves stack trace via the err object", () => {
     const error = new Error("oops");
-    logMessage.error(error);
+    logMessage.error("Operation failed", error);
     const call = mockPinoInstance.error.mock.calls[0];
     expect(call[0]).toEqual({ err: error });
     expect(call[0].err.stack).toContain("oops");
   });
 
-  it("logs a string error directly", () => {
-    logMessage.error("plain error string");
-    expect(mockPinoInstance.error).toHaveBeenCalledWith("plain error string");
-  });
-
-  it("serializes unknown non-string values as JSON", () => {
-    logMessage.error({ code: 404, detail: "not found" });
+  it("appends a string cause to message", () => {
+    logMessage.error("Could not load session", "connection refused");
     expect(mockPinoInstance.error).toHaveBeenCalledWith(
-      JSON.stringify({ code: 404, detail: "not found" })
+      "Could not load session: connection refused"
     );
   });
 
-  it("falls back gracefully when JSON.stringify throws", () => {
+  it("serializes an unknown object cause as JSON appended to message", () => {
+    const obj = { code: 404, detail: "not found" };
+    logMessage.error("Upstream error", obj);
+    expect(mockPinoInstance.error).toHaveBeenCalledWith(`Upstream error: ${JSON.stringify(obj)}`);
+  });
+
+  it("falls back gracefully when JSON.stringify throws on cause", () => {
     const circular: Record<string, unknown> = {};
     circular.self = circular;
-    logMessage.error(circular);
+    logMessage.error("Serialization failed", circular);
     const call = mockPinoInstance.error.mock.calls[0][0] as string;
     expect(call).toContain("Failed to serialize error payload");
     expect(call).toContain("[Object]");
@@ -93,7 +102,7 @@ describe("logMessage.error", () => {
       code = 7;
     }
     const error = new CustomError("connect error");
-    logMessage.error(error);
-    expect(mockPinoInstance.error).toHaveBeenCalledWith({ err: error }, "connect error");
+    logMessage.error("Failed to connect", error);
+    expect(mockPinoInstance.error).toHaveBeenCalledWith({ err: error }, "Failed to connect");
   });
 });

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -74,14 +74,15 @@ export const logMessage: AppLogger = {
   error: (message: unknown) => {
     try {
       if (message instanceof Error) {
-        pinoLogger.error(message.message);
+        pinoLogger.error({ err: message }, message.message);
       } else if (typeof message === "string") {
         pinoLogger.error(message);
       } else {
         pinoLogger.error(JSON.stringify(message));
       }
     } catch {
-      pinoLogger.error("Failed to serialize error log payload");
+      const typeName = message?.constructor?.name ?? typeof message;
+      pinoLogger.error(`Failed to serialize error payload [${typeName}]: ${String(message)}`);
     }
   },
 };

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -29,39 +29,33 @@ export type AppLogger = {
   debug(message: string | Record<string, unknown>): void;
   info(message: string): void;
   warn(message: string): void;
-  error(message: unknown): void;
+  error(message: string, cause?: unknown): void;
 };
 
 /**
  * App logger instance.
  * @example
- * // ✅ Correct - string message
- * logMessage.error(`Failed to load user: ${error.message}`);
- * logMessage.info("User loaded successfully");
+ * // ✅ Correct - message only
+ * logMessage.error("Could not load session");
  *
- * // ✅ Correct - Error object with error method
- * logMessage.error(error); // Automatically extracts error.message
+ * // ✅ Correct - message + Error cause (preserves stack trace)
+ * logMessage.error("Failed to get user", error);
  *
- * // ✅ Correct - unknown from catch blocks
- * logMessage.error(e); // Handles Error, string, or other types
+ * // ✅ Correct - message + unknown from catch blocks
+ * logMessage.error("Failed to get user", e);
  *
  * // ✅ Correct - serialized object with debug
  * logMessage.debug({ userId: 123, action: "login" });
  *
- * // ❌ Incorrect - objects not allowed for info/warn/error
+ * // ❌ Incorrect - objects not allowed for info/warn
  * logMessage.info({ user }); // Type error
- * logMessage.error({ error }, "msg"); // Type error
+ * logMessage.warn({ user }); // Type error
  */
 export const logMessage: AppLogger = {
   debug: (message: string | Record<string, unknown>) => {
     try {
       pinoLogger.debug(message);
     } catch {
-      if (typeof message === "string") {
-        pinoLogger.debug(message);
-        return;
-      }
-
       try {
         pinoLogger.debug(JSON.stringify(message));
       } catch {
@@ -71,18 +65,19 @@ export const logMessage: AppLogger = {
   },
   info: (message: string) => pinoLogger.info(message),
   warn: (message: string) => pinoLogger.warn(message),
-  error: (message: unknown) => {
+  error: (message: string, cause?: unknown) => {
     try {
-      if (message instanceof Error) {
-        pinoLogger.error({ err: message }, message.message);
-      } else if (typeof message === "string") {
-        pinoLogger.error(message);
+      if (cause instanceof Error) {
+        pinoLogger.error({ err: cause }, message);
+      } else if (cause !== undefined) {
+        const serialized = typeof cause === "string" ? cause : JSON.stringify(cause);
+        pinoLogger.error(`${message}: ${serialized}`);
       } else {
-        pinoLogger.error(JSON.stringify(message));
+        pinoLogger.error(message);
       }
     } catch {
-      const typeName = message?.constructor?.name ?? typeof message;
-      pinoLogger.error(`Failed to serialize error payload [${typeName}]: ${String(message)}`);
+      const typeName = cause?.constructor?.name ?? typeof cause;
+      pinoLogger.error(`Failed to serialize error payload [${typeName}]: ${String(cause)}`);
     }
   },
 };

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -77,7 +77,9 @@ export const logMessage: AppLogger = {
       }
     } catch {
       const typeName = cause?.constructor?.name ?? typeof cause;
-      pinoLogger.error(`Failed to serialize error payload [${typeName}]: ${String(cause)}`);
+      pinoLogger.error(
+        `Failed to serialize error payload: ${message}: [${typeName}]: ${String(cause)}`
+      );
     }
   },
 };

--- a/lib/oidc.ts
+++ b/lib/oidc.ts
@@ -94,7 +94,7 @@ export async function loginWithOIDCAndSession({
         }
       } catch (error: unknown) {
         // handle already handled gracefully as these could come up if old emails with requestId are used (reset password, register emails etc.)
-        logMessage.error(error);
+        logMessage.error("OIDC authentication error", error);
         if (error && typeof error === "object" && "code" in error && error?.code === 9) {
           // Already-handled auth requests can happen due to retries or duplicate RSC renders.
           // In that case, recover with a deterministic redirect to the relying party when possible.

--- a/lib/oidc.ts
+++ b/lib/oidc.ts
@@ -33,7 +33,7 @@ export async function loginWithOIDCAndSession({
   const authRequestId = toAuthRequestId(authRequest);
   const oidcRequestId = toOidcRequestId(authRequest);
 
-  logMessage.debug(`OIDC login attempt for requestId: ${oidcRequestId}`);
+  logMessage.info(`OIDC login attempt for requestId: ${oidcRequestId}`);
 
   const selectedSession = sessions.find((s) => s.id === sessionId);
 

--- a/lib/oidc.ts
+++ b/lib/oidc.ts
@@ -13,6 +13,7 @@ import { toAuthRequestId, toOidcRequestId } from "@lib/oidc-request-id";
 import { sendLoginname, SendLoginnameCommand } from "@lib/server/loginname";
 import { createCallback, getAuthRequest, getLoginSettings } from "@lib/zitadel";
 
+import { logMessage } from "./logger";
 import { isSessionValid } from "./session";
 
 type LoginWithOIDCAndSession = {
@@ -32,22 +33,24 @@ export async function loginWithOIDCAndSession({
   const authRequestId = toAuthRequestId(authRequest);
   const oidcRequestId = toOidcRequestId(authRequest);
 
-  console.log(`Login with session: ${sessionId} and authRequest: ${authRequest}`);
+  logMessage.debug(`OIDC login attempt for requestId: ${oidcRequestId}`);
 
   const selectedSession = sessions.find((s) => s.id === sessionId);
 
   if (selectedSession && selectedSession.id) {
-    console.log(`Found session ${selectedSession.id}`);
+    logMessage.debug(`Found session ${selectedSession.id} for OIDC requestId: ${oidcRequestId}`);
 
     const isValid = await isSessionValid({
       serviceUrl,
       session: selectedSession,
     });
 
-    console.log("Session is valid:", isValid);
+    logMessage.debug(`OIDC session validity for requestId ${oidcRequestId}: ${isValid}`);
 
     if (!isValid && selectedSession.factors?.user) {
-      console.log("Session is not valid, need to re-authenticate user");
+      logMessage.info(
+        `OIDC session expired for requestId: ${oidcRequestId}, redirecting for re-authentication`
+      );
       // if the session is not valid anymore, we need to redirect the user to re-authenticate /
       // TODO: handle IDP intent direcly if available
       const command: SendLoginnameCommand = {
@@ -59,7 +62,7 @@ export async function loginWithOIDCAndSession({
       const res = await sendLoginname(command);
 
       if (res && "redirect" in res && res?.redirect) {
-        console.log("Redirecting to re-authenticate:", res.redirect);
+        logMessage.debug(`Re-authentication redirect initiated for requestId: ${oidcRequestId}`);
         return { redirect: res.redirect };
       }
     }
@@ -84,14 +87,14 @@ export async function loginWithOIDCAndSession({
           }),
         });
         if (callbackUrl) {
-          console.log("Redirecting to callback URL:", callbackUrl);
+          logMessage.info(`OIDC authentication complete for requestId: ${oidcRequestId}`);
           return { redirect: callbackUrl };
         } else {
           return { error: "An error occurred!" };
         }
       } catch (error: unknown) {
         // handle already handled gracefully as these could come up if old emails with requestId are used (reset password, register emails etc.)
-        console.error(error);
+        logMessage.error(error);
         if (error && typeof error === "object" && "code" in error && error?.code === 9) {
           // Already-handled auth requests can happen due to retries or duplicate RSC renders.
           // In that case, recover with a deterministic redirect to the relying party when possible.

--- a/lib/server/auth-flow.ts
+++ b/lib/server/auth-flow.ts
@@ -30,7 +30,7 @@ export async function completeAuthFlow(
   const { sessionId, requestId } = command;
 
   logMessage.info(
-    `Completing ${requestId.startsWith("oidc_") ? "OIDC" : requestId.startsWith("saml_") ? "SAML" : "unknown"} auth flow for requestId: ${requestId}`
+    `Completing ${requestId.startsWith("oidc_") ? "OIDC" : "unknown"} auth flow for requestId: ${requestId}`
   );
 
   const _headers = await headers();

--- a/lib/server/auth-flow.ts
+++ b/lib/server/auth-flow.ts
@@ -5,6 +5,7 @@
  *--------------------------------------------*/
 import { headers } from "next/headers";
 
+import { logMessage } from "@lib/logger";
 /*--------------------------------------------*
  * Internal Aliases
  *--------------------------------------------*/
@@ -27,6 +28,10 @@ export async function completeAuthFlow(
   command: AuthFlowParams
 ): Promise<{ error: string } | { redirect: string }> {
   const { sessionId, requestId } = command;
+
+  logMessage.info(
+    `Completing ${requestId.startsWith("oidc_") ? "OIDC" : requestId.startsWith("saml_") ? "SAML" : "unknown"} auth flow for requestId: ${requestId}`
+  );
 
   const _headers = await headers();
   const { serviceUrl } = getServiceUrlFromHeaders(_headers);
@@ -52,11 +57,15 @@ export async function completeAuthFlow(
       typeof result !== "object" ||
       (!("redirect" in result) && !("error" in result))
     ) {
+      logMessage.warn(
+        `OIDC auth flow returned unexpected result structure for requestId: ${requestId}`
+      );
       return { error: "Authentication completed but navigation failed" };
     }
 
     return result;
   }
 
+  logMessage.warn("Auth flow received invalid requestId format");
   return { error: "Invalid request ID format" };
 }

--- a/lib/server/flow-initiation.ts
+++ b/lib/server/flow-initiation.ts
@@ -86,9 +86,7 @@ async function safeFindValidSession({
       authRequest,
     });
   } catch (error) {
-    logMessage.error(
-      `Failed to resolve valid session during flow initiation: ${error instanceof Error ? error.message : String(error)}`
-    );
+    logMessage.error("Failed to resolve valid session during flow initiation", error);
     return undefined;
   }
 }
@@ -260,9 +258,7 @@ export async function handleOIDCFlowInitiation(
             return NextResponse.redirect(absoluteUrl.toString());
           }
         } catch (error) {
-          logMessage.error(
-            `sendLoginname failed during OIDC login hint flow: ${error instanceof Error ? error.message : String(error)}`
-          );
+          logMessage.error("sendLoginname failed during OIDC login hint flow", error);
         }
       }
 
@@ -367,7 +363,7 @@ export async function handleOIDCFlowInitiation(
           });
         }
       } catch (error) {
-        logMessage.error(error);
+        logMessage.error("Flow initiation failed, redirecting to login", error);
         return gotoLogin({
           request,
           requestId: oidcRequestId,

--- a/lib/server/flow-initiation.ts
+++ b/lib/server/flow-initiation.ts
@@ -26,6 +26,8 @@ import {
   startIdentityProviderFlow,
 } from "@lib/zitadel";
 
+import { logMessage } from "../logger";
+
 const ORG_SCOPE_REGEX = /urn:zitadel:iam:org:id:([0-9]+)/;
 const ORG_DOMAIN_SCOPE_REGEX = /urn:zitadel:iam:org:domain:primary:(.+)/;
 const IDP_SCOPE_REGEX = /urn:zitadel:iam:org:idp:id:(.+)/;
@@ -84,7 +86,9 @@ async function safeFindValidSession({
       authRequest,
     });
   } catch (error) {
-    console.error("Failed to resolve valid session during flow initiation:", error);
+    logMessage.error(
+      `Failed to resolve valid session during flow initiation: ${error instanceof Error ? error.message : String(error)}`
+    );
     return undefined;
   }
 }
@@ -125,8 +129,8 @@ export async function handleOIDCFlowInitiation(
         const matched = ORG_DOMAIN_SCOPE_REGEX.exec(orgDomainScope);
         const orgDomain = matched?.[1] ?? "";
 
-        console.log("Extracted org domain:", orgDomain);
         if (orgDomain) {
+          logMessage.debug(`Extracted org domain for OIDC requestId: ${requestId}`);
           const orgs = await getOrgsByDomain({
             serviceUrl,
             domain: orgDomain,
@@ -256,7 +260,9 @@ export async function handleOIDCFlowInitiation(
             return NextResponse.redirect(absoluteUrl.toString());
           }
         } catch (error) {
-          console.error("Failed to execute sendLoginname:", error);
+          logMessage.error(
+            `sendLoginname failed during OIDC login hint flow: ${error instanceof Error ? error.message : String(error)}`
+          );
         }
       }
 
@@ -352,14 +358,16 @@ export async function handleOIDCFlowInitiation(
         if (callbackUrl) {
           return NextResponse.redirect(callbackUrl);
         } else {
-          console.log("could not create callback, redirect user to login");
+          logMessage.warn(
+            `Could not create OIDC callback, redirecting to login for requestId: ${oidcRequestId}`
+          );
           return gotoLogin({
             request,
             requestId: oidcRequestId,
           });
         }
       } catch (error) {
-        console.error(error);
+        logMessage.error(error);
         return gotoLogin({
           request,
           requestId: oidcRequestId,

--- a/lib/server/loginname.ts
+++ b/lib/server/loginname.ts
@@ -79,7 +79,7 @@ export async function sendLoginname(command: SendLoginnameCommand) {
   }
 
   if ("error" in searchResult && searchResult.error) {
-    logMessage.warn("searchUsers returned an error, returning early");
+    logMessage.warn(`searchUsers returned an error, returning early: ${searchResult.error}`);
     return searchResult;
   }
 

--- a/lib/server/loginname.ts
+++ b/lib/server/loginname.ts
@@ -20,6 +20,7 @@ import { serverTranslation } from "@i18n/server";
  * Parent Relative
  *--------------------------------------------*/
 import { idpTypeToIdentityProviderType, idpTypeToSlug } from "../idp";
+import { logMessage } from "../logger";
 import { getServiceUrlFromHeaders } from "../service-url";
 import { buildUrlWithRequestId } from "../utils";
 import {
@@ -73,17 +74,17 @@ export async function sendLoginname(command: SendLoginnameCommand) {
 
   // Safety check: ensure searchResult is defined
   if (!searchResult) {
-    console.error("searchUsers returned undefined or null");
+    logMessage.error("searchUsers returned undefined or null");
     return { error: t("errors.couldNotSearchUsers") };
   }
 
   if ("error" in searchResult && searchResult.error) {
-    console.log("searchUsers returned error, returning early:", searchResult.error);
+    logMessage.warn("searchUsers returned an error, returning early");
     return searchResult;
   }
 
   if (!("result" in searchResult)) {
-    console.log("searchUsers has no result field");
+    logMessage.warn("searchUsers response has no result field");
     return { error: t("errors.couldNotSearchUsers") };
   }
 
@@ -93,7 +94,7 @@ export async function sendLoginname(command: SendLoginnameCommand) {
   const users = potentialUsers ?? [];
 
   if (users.length === 0) {
-    console.log("No users found, will proceed with org discovery");
+    logMessage.debug("No users found, will proceed with org discovery");
   }
 
   const redirectUserToIDP = async (userId?: string, organization?: string) => {
@@ -222,7 +223,7 @@ export async function sendLoginname(command: SendLoginnameCommand) {
   };
 
   if (users.length > 1) {
-    console.log("multiple users found, returning error");
+    logMessage.warn("Multiple users found for login attempt, returning error");
     return { error: t("errors.moreThanOneUserFound") };
   } else if (users.length == 1 && users[0].userId) {
     const user = users[0];
@@ -424,7 +425,7 @@ export async function sendLoginname(command: SendLoginnameCommand) {
     }
   }
 
-  console.log("user not found (0 potential users), checking registration options");
+  logMessage.debug("No users found (0 potential users), checking registration options");
 
   // user not found, perform organization discovery if no org context provided
   let discoveredOrganization = command.organization;
@@ -450,35 +451,35 @@ export async function sendLoginname(command: SendLoginnameCommand) {
       });
 
       if (orgLoginSettings?.allowDomainDiscovery) {
-        console.log("org discovery successful, using org:", orgToCheckForDiscovery);
+        logMessage.debug(`Org domain discovery successful, using org: ${orgToCheckForDiscovery}`);
         discoveredOrganization = orgToCheckForDiscovery;
         // Use the discovered organization's login settings for subsequent checks
         effectiveLoginSettings = orgLoginSettings;
       } else {
-        console.log("org does not allow domain discovery");
+        logMessage.debug("Org does not allow domain discovery");
       }
     } else {
-      console.log("no single org found for discovery");
+      logMessage.debug("No single org found for domain discovery");
     }
   }
 
   // user not found, check if register is enabled on instance / organization context
   if (effectiveLoginSettings?.allowRegister && !effectiveLoginSettings?.allowUsernamePassword) {
-    console.log("redirecting to IDP (register allowed, password not allowed)");
+    logMessage.debug("Redirecting to IDP (register allowed, password not allowed)");
     const resp = await redirectUserToIDP(undefined, discoveredOrganization);
     if (resp) {
       return resp;
     }
-    console.log("IDP redirect failed, returning user not found");
+    logMessage.warn("IDP redirect failed, returning user not found");
     return { error: t("errors.userNotFound") };
   } else if (
     effectiveLoginSettings?.allowRegister &&
     effectiveLoginSettings?.allowUsernamePassword
   ) {
-    console.log("register and password both allowed");
+    logMessage.debug("Register and password both allowed");
     // do not register user if ignoreUnknownUsernames is set
     if (discoveredOrganization && !effectiveLoginSettings?.ignoreUnknownUsernames) {
-      console.log("redirecting to registration page with org:", discoveredOrganization);
+      logMessage.debug("Redirecting to registration page");
       const params = new URLSearchParams({ organization: discoveredOrganization });
 
       if (command.requestId) {
@@ -491,15 +492,14 @@ export async function sendLoginname(command: SendLoginnameCommand) {
 
       return { redirect: "/register?" + params };
     } else {
-      console.log("not redirecting to register:", {
-        hasDiscoveredOrg: !!discoveredOrganization,
-        ignoreUnknownUsernames: effectiveLoginSettings?.ignoreUnknownUsernames,
-      });
+      logMessage.debug(
+        `Not redirecting to register (hasDiscoveredOrg: ${!!discoveredOrganization}, ignoreUnknownUsernames: ${effectiveLoginSettings?.ignoreUnknownUsernames})`
+      );
     }
   }
 
   if (effectiveLoginSettings?.ignoreUnknownUsernames) {
-    console.log("ignoreUnknownUsernames is true, redirecting to password");
+    logMessage.debug("ignoreUnknownUsernames is set, redirecting to password");
     const paramsPasswordDefault = new URLSearchParams({
       loginName: command.loginName,
     });
@@ -515,6 +515,6 @@ export async function sendLoginname(command: SendLoginnameCommand) {
     return { redirect: "/password?" + paramsPasswordDefault };
   }
 
-  console.log("no valid registration option found, returning user not found");
+  logMessage.info("No valid login or registration path found, returning user not found");
   return { error: t("errors.userNotFound") };
 }

--- a/lib/server/otp.ts
+++ b/lib/server/otp.ts
@@ -122,6 +122,7 @@ export async function sendOtpEmail(command: SendOtpEmailCommand) {
     const gcNotify = GCNotifyConnector.default(apiKey);
     await gcNotify.sendEmail(userEmail, templateId, getSecurityCodeTemplate(otpCode));
 
+    logMessage.info("OTP email sent successfully");
     return {
       success: true,
       sessionId: session.id,

--- a/lib/server/otp.ts
+++ b/lib/server/otp.ts
@@ -85,9 +85,7 @@ export async function sendOtpEmail(command: SendOtpEmailCommand) {
     requestId,
     lifetime: lifetime as Duration,
   }).catch((error) => {
-    logMessage.error(
-      `Could not set session for OTP challenge: ${error instanceof Error ? error.message : String(error)}`
-    );
+    logMessage.error("Could not set session for OTP challenge", error);
     return null;
   });
 
@@ -130,9 +128,7 @@ export async function sendOtpEmail(command: SendOtpEmailCommand) {
       factors: session.factors,
     };
   } catch (error) {
-    logMessage.error(
-      `Failed to send OTP email via GC Notify: ${error instanceof Error ? error.message : String(error)}`
-    );
+    logMessage.error("Failed to send OTP email via GC Notify", error);
     return { error: t("errors.emailSendFailed") };
   }
 }

--- a/lib/server/otp.ts
+++ b/lib/server/otp.ts
@@ -25,6 +25,7 @@ import {
   getSessionCookieById,
   getSessionCookieByLoginName,
 } from "../cookies";
+import { logMessage } from "../logger";
 
 type SendOtpEmailCommand = {
   loginName?: string;
@@ -84,7 +85,9 @@ export async function sendOtpEmail(command: SendOtpEmailCommand) {
     requestId,
     lifetime: lifetime as Duration,
   }).catch((error) => {
-    console.error("Could not set session for OTP challenge", error);
+    logMessage.error(
+      `Could not set session for OTP challenge: ${error instanceof Error ? error.message : String(error)}`
+    );
     return null;
   });
 
@@ -96,7 +99,7 @@ export async function sendOtpEmail(command: SendOtpEmailCommand) {
   const otpCode = session.challenges?.otpEmail;
 
   if (!otpCode) {
-    console.error("No OTP code returned from Zitadel");
+    logMessage.error("No OTP code returned from Zitadel");
     return { error: t("errors.couldNotGenerateOtp") };
   }
 
@@ -113,7 +116,7 @@ export async function sendOtpEmail(command: SendOtpEmailCommand) {
   const templateId = process.env.TEMPLATE_ID;
 
   if (!apiKey || !templateId) {
-    console.error("Missing NOTIFY_API_KEY or TEMPLATE_ID environment variables");
+    logMessage.error("Missing NOTIFY_API_KEY or TEMPLATE_ID environment variables");
     return { error: t("errors.emailConfigurationError") };
   }
 
@@ -127,7 +130,9 @@ export async function sendOtpEmail(command: SendOtpEmailCommand) {
       factors: session.factors,
     };
   } catch (error) {
-    console.error("Failed to send OTP email via GC Notify", error);
+    logMessage.error(
+      `Failed to send OTP email via GC Notify: ${error instanceof Error ? error.message : String(error)}`
+    );
     return { error: t("errors.emailSendFailed") };
   }
 }

--- a/lib/server/password.ts
+++ b/lib/server/password.ts
@@ -574,7 +574,7 @@ export async function checkSessionAndSetPassword({
   try {
     sessionCookie = await getSessionCookieById({ sessionId });
   } catch (error) {
-    logMessage.error(error);
+    logMessage.error("Could not load session cookie", error);
     return { error: "Could not load session cookie" };
   }
 
@@ -587,7 +587,7 @@ export async function checkSessionAndSetPassword({
     });
     session = sessionResponse.session;
   } catch (error) {
-    logMessage.error(error);
+    logMessage.error("Could not load session", error);
     return { error: "Could not load session" };
   }
 
@@ -610,7 +610,7 @@ export async function checkSessionAndSetPassword({
       userId: session.factors.user.id,
     });
   } catch (error) {
-    logMessage.error(error);
+    logMessage.error("Could not load auth methods", error);
     return { error: "Could not load auth methods" };
   }
 
@@ -625,7 +625,7 @@ export async function checkSessionAndSetPassword({
       organization: session.factors.user.organizationId,
     });
   } catch (error) {
-    logMessage.error(error);
+    logMessage.error("Could not load login settings", error);
     return { error: "Could not load login settings" };
   }
 
@@ -691,7 +691,7 @@ export async function checkSessionAndSetPassword({
         return result;
       })
       .catch((error: ConnectError) => {
-        logMessage.error(error);
+        logMessage.error("Could not set password", error);
         if (error.code === 7) {
           return { error: t("errors.sessionNotValid") };
         }

--- a/lib/server/password.ts
+++ b/lib/server/password.ts
@@ -408,12 +408,11 @@ export async function sendPassword(
 
   if (command.requestId && session.id) {
     // OIDC flow - use completeFlowOrGetUrl for proper handling
-    console.log(
-      "Password auth: OIDC flow with requestId:",
-      command.requestId,
-      "sessionId:",
-      session.id
-    );
+    logMessage.debug({
+      message: "Password auth: OIDC flow with requestId",
+      requestId: command.requestId,
+      sessionId: session.id,
+    });
     const result = await completeFlowOrGetUrl(
       {
         sessionId: session.id,
@@ -422,7 +421,10 @@ export async function sendPassword(
       },
       loginSettings?.defaultRedirectUri
     );
-    console.log("Password auth: OIDC flow result:", result);
+    logMessage.debug({
+      message: "Password auth: OIDC flow result",
+      result,
+    });
 
     // Safety net - ensure we always return a valid object
     if (
@@ -430,7 +432,7 @@ export async function sendPassword(
       typeof result !== "object" ||
       (!("redirect" in result) && !("error" in result))
     ) {
-      console.error("Password auth: Invalid result from completeFlowOrGetUrl (OIDC):", result);
+      logMessage.error("Password auth: Invalid result from completeFlowOrGetUrl (OIDC)", result);
       return { error: "Authentication completed but navigation failed" };
     }
 

--- a/lib/server/password.ts
+++ b/lib/server/password.ts
@@ -127,7 +127,7 @@ export async function resetPassword(command: ResetPasswordCommand) {
 
   const { t } = await serverTranslation("password");
 
-  // Get the original host that the user sees with protocol
+  logMessage.info("Password reset requested");
   const hostWithProtocol = await getOriginalHostWithProtocol();
 
   const users = await listUsers({
@@ -438,7 +438,7 @@ export async function sendPassword(
   }
 
   // Regular flow (no requestId) - return URL for client-side navigation
-  console.log("Password auth: Regular flow with loginName:", session.factors.user.loginName);
+  logMessage.debug("Password auth: completing regular flow");
   const result = await completeFlowOrGetUrl(
     {
       loginName: session.factors.user.loginName,
@@ -446,11 +446,10 @@ export async function sendPassword(
     },
     loginSettings?.defaultRedirectUri
   );
-  console.log("Password auth: Regular flow result:", result);
 
   // Safety net - ensure we always return a valid object
   if (!result || typeof result !== "object" || (!("redirect" in result) && !("error" in result))) {
-    console.error("Password auth: Invalid result from completeFlowOrGetUrl:", result);
+    logMessage.error("Password auth: Invalid result from completeFlowOrGetUrl");
     return { error: "Authentication completed but navigation failed" };
   }
 
@@ -537,6 +536,7 @@ export async function changePassword(command: { code?: string; userId: string; p
 
     // Send password changed email notification
     if (didPasswordChangeSucceed(result)) {
+      logMessage.info("Password changed successfully");
       await sendPasswordChangedEmail({ userId }).catch((error) => {
         logMessage.debug({
           error: error instanceof Error ? error.message : error,
@@ -574,7 +574,7 @@ export async function checkSessionAndSetPassword({
   try {
     sessionCookie = await getSessionCookieById({ sessionId });
   } catch (error) {
-    console.error("Error getting session cookie:", error);
+    logMessage.error(error);
     return { error: "Could not load session cookie" };
   }
 
@@ -587,7 +587,7 @@ export async function checkSessionAndSetPassword({
     });
     session = sessionResponse.session;
   } catch (error) {
-    console.error("Error getting session:", error);
+    logMessage.error(error);
     return { error: "Could not load session" };
   }
 
@@ -610,7 +610,7 @@ export async function checkSessionAndSetPassword({
       userId: session.factors.user.id,
     });
   } catch (error) {
-    console.error("Error getting auth methods:", error);
+    logMessage.error(error);
     return { error: "Could not load auth methods" };
   }
 
@@ -625,7 +625,7 @@ export async function checkSessionAndSetPassword({
       organization: session.factors.user.organizationId,
     });
   } catch (error) {
-    console.error("Error getting login settings:", error);
+    logMessage.error(error);
     return { error: "Could not load login settings" };
   }
 
@@ -633,8 +633,8 @@ export async function checkSessionAndSetPassword({
 
   // if the user has no MFA but MFA is enforced, we can set a password otherwise we use the token of the user
   if (forceMfa) {
-    console.log(
-      "Set password using service account due to enforced MFA without existing MFA methods"
+    logMessage.info(
+      "Setting password via service account due to enforced MFA without existing MFA methods"
     );
     return setPassword({ serviceUrl, payload })
       .then(async (result) => {
@@ -691,7 +691,7 @@ export async function checkSessionAndSetPassword({
         return result;
       })
       .catch((error: ConnectError) => {
-        console.log(error);
+        logMessage.error(error);
         if (error.code === 7) {
           return { error: t("errors.sessionNotValid") };
         }

--- a/lib/server/session.ts
+++ b/lib/server/session.ts
@@ -358,7 +358,7 @@ export async function logoutCurrentSession(
     const redirectUrl = `/`;
     return { redirect: redirectUrl };
   } catch (error) {
-    logMessage.info("Error during logout");
+    logMessage.error("Error during logout", error);
     return { error: "Failed to logout" };
   }
 }

--- a/lib/server/zitadel-protected.ts
+++ b/lib/server/zitadel-protected.ts
@@ -44,9 +44,7 @@ export const protectedGetUserByID = AuthenticatedAction(
       const { serviceUrl } = getServiceUrlFromHeaders(_headers);
       return await z.getUserByID({ serviceUrl, userId });
     } catch (error) {
-      logMessage.error(
-        `Failed to get user ${userId}: ${error instanceof Error ? error.message : String(error)}`
-      );
+      logMessage.error(`Failed to get user ${userId}`, error);
       return { error: "Failed to retrieve user" };
     }
   }
@@ -76,9 +74,7 @@ export const protectedListIDPLinks = AuthenticatedAction(
       const { serviceUrl } = getServiceUrlFromHeaders(_headers);
       return await z.listIDPLinks({ serviceUrl, userId });
     } catch (error) {
-      logMessage.error(
-        `Failed to list IDP links for ${userId}: ${error instanceof Error ? error.message : String(error)}`
-      );
+      logMessage.error(`Failed to list IDP links for ${userId}`, error);
       return { error: "Failed to list IDP links" };
     }
   }
@@ -108,9 +104,7 @@ export const protectedRegisterTOTP = AuthenticatedAction(
       const { serviceUrl } = getServiceUrlFromHeaders(_headers);
       return await z.registerTOTP({ serviceUrl, userId });
     } catch (error) {
-      logMessage.error(
-        `Failed to register TOTP for ${userId}: ${error instanceof Error ? error.message : String(error)}`
-      );
+      logMessage.error(`Failed to register TOTP for ${userId}`, error);
       return { error: "Failed to register TOTP" };
     }
   }
@@ -140,9 +134,7 @@ export const protectedVerifyTOTPRegistration = AuthenticatedAction(
       const { serviceUrl } = getServiceUrlFromHeaders(_headers);
       return await z.verifyTOTPRegistration({ serviceUrl, userId, code });
     } catch (error) {
-      logMessage.error(
-        `Failed to verify TOTP for ${userId}: ${error instanceof Error ? error.message : String(error)}`
-      );
+      logMessage.error(`Failed to verify TOTP for ${userId}`, error);
       return { error: "Failed to verify TOTP" };
     }
   }
@@ -172,9 +164,7 @@ export const protectedAddOTPEmail = AuthenticatedAction(
       const { serviceUrl } = getServiceUrlFromHeaders(_headers);
       return await z.addOTPEmail({ serviceUrl, userId });
     } catch (error) {
-      logMessage.error(
-        `Failed to add OTP email for ${userId}: ${error instanceof Error ? error.message : String(error)}`
-      );
+      logMessage.error(`Failed to add OTP email for ${userId}`, error);
       return { error: "Failed to add OTP email" };
     }
   }
@@ -204,9 +194,7 @@ export const protectedAddOTPSMS = AuthenticatedAction(
       const { serviceUrl } = getServiceUrlFromHeaders(_headers);
       return await z.addOTPSMS({ serviceUrl, userId });
     } catch (error) {
-      logMessage.error(
-        `Failed to add OTP SMS for ${userId}: ${error instanceof Error ? error.message : String(error)}`
-      );
+      logMessage.error(`Failed to add OTP SMS for ${userId}`, error);
       return { error: "Failed to add OTP SMS" };
     }
   }
@@ -236,9 +224,7 @@ export const protectedRegisterU2F = AuthenticatedAction(
       const { serviceUrl } = getServiceUrlFromHeaders(_headers);
       return await z.registerU2F({ serviceUrl, userId, domain });
     } catch (error) {
-      logMessage.error(
-        `Failed to register U2F for ${userId}: ${error instanceof Error ? error.message : String(error)}`
-      );
+      logMessage.error(`Failed to register U2F for ${userId}`, error);
       return { error: "Failed to register U2F" };
     }
   }
@@ -280,9 +266,7 @@ export const protectedVerifyU2FRegistration = AuthenticatedAction(
       const { serviceUrl } = getServiceUrlFromHeaders(_headers);
       return await z.verifyU2FRegistration({ serviceUrl, request });
     } catch (error) {
-      logMessage.error(
-        `Failed to verify U2F for ${userId}: ${error instanceof Error ? error.message : String(error)}`
-      );
+      logMessage.error(`Failed to verify U2F for ${userId}`, error);
       return { error: "Failed to verify U2F" };
     }
   }
@@ -312,9 +296,7 @@ export const protectedRemoveU2F = AuthenticatedAction(
       const { serviceUrl } = getServiceUrlFromHeaders(_headers);
       return await z.removeU2F({ serviceUrl, userId, u2fId });
     } catch (error) {
-      logMessage.error(
-        `Failed to remove U2F for ${userId}: ${error instanceof Error ? error.message : String(error)}`
-      );
+      logMessage.error(`Failed to remove U2F for ${userId}`, error);
       return { error: "Failed to remove U2F" };
     }
   }
@@ -344,9 +326,7 @@ export const protectedRemoveTOTP = AuthenticatedAction(
       const { serviceUrl } = getServiceUrlFromHeaders(_headers);
       return await z.removeTOTP({ serviceUrl, userId });
     } catch (error) {
-      logMessage.error(
-        `Failed to remove TOTP for ${userId}: ${error instanceof Error ? error.message : String(error)}`
-      );
+      logMessage.error(`Failed to remove TOTP for ${userId}`, error);
       return { error: "Failed to remove TOTP" };
     }
   }
@@ -376,9 +356,7 @@ export const protectedGetTOTPStatus = AuthenticatedAction(
       const { serviceUrl } = getServiceUrlFromHeaders(_headers);
       return await z.getTOTPStatus({ serviceUrl, userId });
     } catch (error) {
-      logMessage.error(
-        `Failed to get TOTP status for ${userId}: ${error instanceof Error ? error.message : String(error)}`
-      );
+      logMessage.error(`Failed to get TOTP status for ${userId}`, error);
       return { error: "Failed to get TOTP status" };
     }
   }
@@ -408,9 +386,7 @@ export const protectedGetU2FList = AuthenticatedAction(
       const { serviceUrl } = getServiceUrlFromHeaders(_headers);
       return await z.getU2FList({ serviceUrl, userId });
     } catch (error) {
-      logMessage.error(
-        `Failed to get U2F list for ${userId}: ${error instanceof Error ? error.message : String(error)}`
-      );
+      logMessage.error(`Failed to get U2F list for ${userId}`, error);
       return { error: "Failed to get U2F list" };
     }
   }
@@ -440,9 +416,7 @@ export const protectedListAuthenticationMethodTypes = AuthenticatedAction(
       const { serviceUrl } = getServiceUrlFromHeaders(_headers);
       return await z.listAuthenticationMethodTypes({ serviceUrl, userId });
     } catch (error) {
-      logMessage.error(
-        `Failed to list auth methods for ${userId}: ${error instanceof Error ? error.message : String(error)}`
-      );
+      logMessage.error(`Failed to list auth methods for ${userId}`, error);
       return { error: "Failed to list auth methods" };
     }
   }
@@ -472,9 +446,7 @@ export const protectedHumanMFAInitSkipped = AuthenticatedAction(
       const { serviceUrl } = getServiceUrlFromHeaders(_headers);
       return await z.humanMFAInitSkipped({ serviceUrl, userId });
     } catch (error) {
-      logMessage.error(
-        `Failed to mark MFA init skipped for ${userId}: ${error instanceof Error ? error.message : String(error)}`
-      );
+      logMessage.error(`Failed to mark MFA init skipped for ${userId}`, error);
       return { error: "Failed to mark MFA init skipped" };
     }
   }
@@ -508,9 +480,7 @@ export const protectedAddIDPLink = AuthenticatedAction(
       const { serviceUrl } = getServiceUrlFromHeaders(_headers);
       return await z.addIDPLink({ serviceUrl, idp, userId });
     } catch (error) {
-      logMessage.error(
-        `Failed to add IDP link for ${userId}: ${error instanceof Error ? error.message : String(error)}`
-      );
+      logMessage.error(`Failed to add IDP link for ${userId}`, error);
       return { error: "Failed to add IDP link" };
     }
   }
@@ -536,9 +506,7 @@ export const protectedGetPasswordExpirySettings = AuthenticatedAction(
         orgId: credentials.organization,
       });
     } catch (error) {
-      logMessage.error(
-        `Failed to get password expiry settings: ${error instanceof Error ? error.message : String(error)}`
-      );
+      logMessage.error("Failed to get password expiry settings", error);
       return { error: "Failed to get password expiry settings" };
     }
   }
@@ -585,9 +553,7 @@ export const protectedUpdatePersonalDetails = AuthenticatedAction(
       });
       return await z.updateHuman({ serviceUrl, request });
     } catch (error) {
-      logMessage.error(
-        `Failed to update user ${userId}: ${error instanceof Error ? error.message : String(error)}`
-      );
+      logMessage.error(`Failed to update user ${userId}`, error);
       return { error: "Failed to update user" };
     }
   }

--- a/lib/zitadel.ts
+++ b/lib/zitadel.ts
@@ -46,6 +46,7 @@ import {
 import { serverTranslation } from "@i18n/server";
 
 import { getUserAgent } from "./fingerprint";
+import { logMessage } from "./logger";
 import { createServiceForHost } from "./service";
 import { getSerializableObject } from "./utils";
 
@@ -344,7 +345,11 @@ export async function createSessionForUserIdAndIdpIntent({
   };
   lifetime: Duration;
 }) {
-  console.log("Creating session for userId and IDP intent", { userId, idpIntent, lifetime });
+  logMessage.debug({
+    message: "Creating IDP intent session",
+    userId,
+    hasIdpIntentId: !!idpIntent.idpIntentId,
+  });
   const sessionService: Client<typeof SessionService> = await createServiceForHost(
     SessionService,
     serviceUrl
@@ -1492,7 +1497,9 @@ export function createServerTransport(token: string, baseUrl: string) {
                 if (kv > 0) {
                   req.header.set(header.slice(0, kv).trim(), header.slice(kv + 1).trim());
                 } else {
-                  console.warn(`Skipping malformed header: ${header}`);
+                  logMessage.warn(
+                    `Skipping malformed CUSTOM_REQUEST_HEADERS entry (expected key:value format)`
+                  );
                 }
               });
               return next(req);


### PR DESCRIPTION
# Summary
Update all server logging to use logMessage and adjust the log level based on the information being logged.  

This also adjust the logger `logMessage.error` behaviour to accept both a `message` string and optional `cause`. If the `cause` is an Error object, Pino's serialization of error properties adds more details to the log message.

# Related
- Closes https://github.com/cds-snc/platform-core-services/issues/979