### PR TITLE
chore: check tab active for updater

### DIFF
--- a/components/auth/VersionUpdater.test.tsx
+++ b/components/auth/VersionUpdater.test.tsx
@@ -24,12 +24,15 @@ describe("VersionUpdater", () => {
     vi.mocked(useVersionUpdater).mockReturnValue({
       latestVersion: "abc1234",
       previousVersion: null,
+      latestShortVersion: "abc1234",
+      previousShortVersion: null,
       didChange: false,
     });
 
     render(<VersionUpdater />);
 
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("version-updater-debug")).not.toBeInTheDocument();
   });
 
   it("shows a refresh dialog and reloads when the user confirms", async () => {
@@ -45,12 +48,15 @@ describe("VersionUpdater", () => {
     vi.mocked(useVersionUpdater).mockReturnValue({
       latestVersion: "def5678",
       previousVersion: "abc1234",
+      latestShortVersion: "def5678",
+      previousShortVersion: "abc1234",
       didChange: true,
     });
 
     render(<VersionUpdater />);
 
     expect(await screen.findByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByTestId("version-updater-debug")).toHaveTextContent("def5678:abc1234");
 
     await userEvent.click(screen.getByRole("button", { name: "refreshNow" }));
 
@@ -61,6 +67,8 @@ describe("VersionUpdater", () => {
     vi.mocked(useVersionUpdater).mockReturnValue({
       latestVersion: "def5678",
       previousVersion: "abc1234",
+      latestShortVersion: "def5678",
+      previousShortVersion: "abc1234",
       didChange: true,
     });
 
@@ -71,5 +79,6 @@ describe("VersionUpdater", () => {
     await userEvent.click(screen.getByRole("button", { name: "close" }));
 
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("version-updater-debug")).not.toBeInTheDocument();
   });
 });

--- a/components/auth/VersionUpdater.tsx
+++ b/components/auth/VersionUpdater.tsx
@@ -36,13 +36,20 @@ function closeDialog(dialog: HTMLDialogElement) {
   dialog.removeAttribute("open");
 }
 
-export function VersionUpdater() {
+function VersionUpdaterDialog({
+  didChange,
+  latestShortVersion,
+  previousShortVersion,
+  onDismiss,
+}: {
+  didChange: boolean;
+  latestShortVersion: string | null;
+  previousShortVersion: string | null;
+  onDismiss: () => void;
+}) {
   const { t } = useTranslation("versionUpdater");
-  const { didChange } = useVersionUpdater();
-  const [dismissed, setDismissed] = useState(false);
   const dialogRef = useRef<HTMLDialogElement | null>(null);
   const refreshButtonRef = useRef<HTMLButtonElement | null>(null);
-  const showDialog = didChange && !dismissed;
 
   useEffect(() => {
     const dialog = dialogRef.current;
@@ -51,19 +58,17 @@ export function VersionUpdater() {
       return;
     }
 
-    if (showDialog && !dialog.open) {
+    if (!dialog.open) {
       openDialog(dialog);
       refreshButtonRef.current?.focus();
     }
 
-    if (!showDialog && dialog.open) {
-      closeDialog(dialog);
-    }
-  }, [showDialog]);
-
-  if (!showDialog || dismissed) {
-    return null;
-  }
+    return () => {
+      if (dialog.open) {
+        closeDialog(dialog);
+      }
+    };
+  }, []);
 
   return (
     <dialog
@@ -71,13 +76,13 @@ export function VersionUpdater() {
       aria-labelledby="version-updater-title"
       aria-describedby="version-updater-description"
       className="fixed inset-0 m-auto w-full max-w-2xl rounded-2xl border border-gray-300 bg-white p-8 shadow-xl backdrop:bg-black/45"
-      onCancel={() => {
-        setDismissed(true);
-      }}
+      onCancel={onDismiss}
       onClose={() => {
         if (!didChange) {
-          setDismissed(false);
+          return;
         }
+
+        onDismiss();
       }}
     >
       <div className="flex items-start justify-between gap-4">
@@ -90,26 +95,24 @@ export function VersionUpdater() {
               {t("title")}
             </h2>
           </div>
-          <p id="version-updater-description" className="text-base text-gray-700">
+
+          <p id="version-updater-description" className="max-w-xl text-base text-gray-700">
             {t("description")}
           </p>
         </div>
 
-        <Button
-          theme="link"
-          aria-label={t("close")}
-          className="group shrink-0"
-          onClick={() => {
-            setDismissed(true);
-          }}
-        >
+        <Button theme="link" aria-label={t("close")} className="group shrink-0" onClick={onDismiss}>
           <span className="block">
             <Close className="inline-block size-6 fill-black group-hover:fill-gcds-blue-vivid group-focus:fill-white-default group-active:fill-white-default" />
           </span>
         </Button>
       </div>
 
-      <div className="mt-8 flex justify-end">
+      <div className="mt-6 flex items-center justify-between gap-3">
+        <div className="text-xs text-gray-500" data-testid="version-updater-debug">
+          {latestShortVersion ?? "unknown"}:{previousShortVersion ?? "unknown"}
+        </div>
+
         <Button
           buttonRef={refreshButtonRef}
           onClick={() => {
@@ -121,4 +124,22 @@ export function VersionUpdater() {
       </div>
     </dialog>
   );
+}
+
+export function VersionUpdater() {
+  const { didChange, latestVersion, latestShortVersion, previousShortVersion } =
+    useVersionUpdater();
+  const [dismissedVersion, setDismissedVersion] = useState<string | null>(null);
+  const showDialog = didChange && latestVersion !== null && latestVersion !== dismissedVersion;
+
+  return showDialog ? (
+    <VersionUpdaterDialog
+      didChange={didChange}
+      latestShortVersion={latestShortVersion}
+      previousShortVersion={previousShortVersion}
+      onDismiss={() => {
+        setDismissedVersion(latestVersion);
+      }}
+    />
+  ) : null;
 }

--- a/components/auth/useLeaderTab.tsx
+++ b/components/auth/useLeaderTab.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+/*--------------------------------------------*
+ * Framework and Third-Party
+ *--------------------------------------------*/
+import {
+  type Dispatch,
+  type RefObject,
+  type SetStateAction,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+
+const LEADER_TAB_COORDINATION_PREFIX = "leader-tab";
+
+type LeaderTabMessage = {
+  type: "claim" | "release";
+  tabId: string;
+};
+
+type LeaderTabState = {
+  leaderTabIdRef: RefObject<string | null>;
+  tabIdRef: RefObject<string>;
+  setIsLeaderTab: Dispatch<SetStateAction<boolean>>;
+};
+
+const getTabId = () => {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+
+  return `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+};
+
+const isTabForeground = () => {
+  if (typeof document === "undefined") {
+    return true;
+  }
+
+  return document.visibilityState === "visible" && document.hasFocus();
+};
+
+const broadcastTabMessage = (coordinationChannel: BroadcastChannel, message: LeaderTabMessage) => {
+  coordinationChannel.postMessage(message);
+};
+
+const claimLeadership = (
+  { leaderTabIdRef, tabIdRef, setIsLeaderTab }: LeaderTabState,
+  coordinationChannel: BroadcastChannel
+) => {
+  leaderTabIdRef.current = tabIdRef.current;
+  setIsLeaderTab(true);
+  broadcastTabMessage(coordinationChannel, { type: "claim", tabId: tabIdRef.current });
+};
+
+const releaseLeadership = (
+  { leaderTabIdRef, tabIdRef, setIsLeaderTab }: LeaderTabState,
+  coordinationChannel: BroadcastChannel,
+  broadcast = true
+) => {
+  const isCurrentLeader = leaderTabIdRef.current === tabIdRef.current;
+
+  if (broadcast && isCurrentLeader) {
+    broadcastTabMessage(coordinationChannel, { type: "release", tabId: tabIdRef.current });
+  }
+
+  if (isCurrentLeader) {
+    leaderTabIdRef.current = null;
+  }
+
+  setIsLeaderTab(false);
+};
+
+const attemptLeadership = (state: LeaderTabState, coordinationChannel: BroadcastChannel) => {
+  if (isTabForeground()) {
+    claimLeadership(state, coordinationChannel);
+    return;
+  }
+
+  releaseLeadership(state, coordinationChannel);
+};
+
+export const useLeaderTab = ({
+  enabled,
+  coordinationKey,
+}: {
+  enabled: boolean;
+  coordinationKey: string;
+}) => {
+  "use memo";
+  const coordinationChannelRef = useRef<BroadcastChannel | null>(null);
+  const leaderTabIdRef = useRef<string | null>(null);
+  const tabIdRef = useRef<string>(getTabId());
+  const [isLeaderTab, setIsLeaderTab] = useState(() => isTabForeground());
+  const coordinationChannelName = `${LEADER_TAB_COORDINATION_PREFIX}:${coordinationKey}`;
+  const fallbackLeaderTab = !enabled || typeof BroadcastChannel === "undefined";
+  const leaderTabState = {
+    leaderTabIdRef,
+    tabIdRef,
+    setIsLeaderTab,
+  } satisfies LeaderTabState;
+
+  useEffect(() => {
+    if (fallbackLeaderTab) {
+      return;
+    }
+
+    const coordinationChannel = new BroadcastChannel(coordinationChannelName);
+    coordinationChannelRef.current = coordinationChannel;
+
+    const handleMessage = (event: MessageEvent<LeaderTabMessage>) => {
+      const message = event.data;
+      if (!message || message.tabId === tabIdRef.current) {
+        return;
+      }
+
+      if (message.type === "claim") {
+        leaderTabIdRef.current = message.tabId;
+        setIsLeaderTab(false);
+        return;
+      }
+
+      if (message.type === "release" && leaderTabIdRef.current === message.tabId) {
+        leaderTabIdRef.current = null;
+
+        if (isTabForeground()) {
+          window.setTimeout(() => {
+            if (leaderTabIdRef.current === null) {
+              claimLeadership(leaderTabState, coordinationChannel);
+            }
+          }, 0);
+        }
+      }
+    };
+
+    const handleFocusChange = () => {
+      attemptLeadership(leaderTabState, coordinationChannel);
+    };
+
+    coordinationChannel.addEventListener("message", handleMessage as EventListener);
+    window.addEventListener("focus", handleFocusChange);
+    window.addEventListener("blur", handleFocusChange);
+    window.addEventListener("pagehide", handleFocusChange);
+    document.addEventListener("visibilitychange", handleFocusChange);
+
+    attemptLeadership(leaderTabState, coordinationChannel);
+
+    return () => {
+      coordinationChannel.removeEventListener("message", handleMessage as EventListener);
+      window.removeEventListener("focus", handleFocusChange);
+      window.removeEventListener("blur", handleFocusChange);
+      window.removeEventListener("pagehide", handleFocusChange);
+      document.removeEventListener("visibilitychange", handleFocusChange);
+      releaseLeadership(leaderTabState, coordinationChannel);
+      coordinationChannel.close();
+      coordinationChannelRef.current = null;
+    };
+  }, [coordinationChannelName, fallbackLeaderTab, leaderTabState]);
+
+  return { isLeaderTab: fallbackLeaderTab ? true : isLeaderTab };
+};

--- a/components/auth/useVersionUpdater.test.tsx
+++ b/components/auth/useVersionUpdater.test.tsx
@@ -1,0 +1,85 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const pollIntervalMs = 60_000;
+
+describe("useVersionUpdater", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+    vi.resetModules();
+  });
+
+  it("only polls when the current tab is the leader tab", async () => {
+    vi.doMock("./useLeaderTab", () => ({
+      useLeaderTab: () => ({ isLeaderTab: false }),
+    }));
+
+    const { useVersionUpdater } = await import("./useVersionUpdater");
+    renderHook(() => useVersionUpdater());
+
+    vi.advanceTimersByTime(pollIntervalMs * 2);
+
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("stores full and short versions after a successful leader-tab poll", async () => {
+    vi.doMock("./useLeaderTab", () => ({
+      useLeaderTab: () => ({ isLeaderTab: true }),
+    }));
+
+    vi.mocked(fetch).mockResolvedValue(
+      new Response("abcdef1234567890", {
+        status: 200,
+        headers: { "content-type": "text/plain" },
+      })
+    );
+
+    const { useVersionUpdater } = await import("./useVersionUpdater");
+    const { result } = renderHook(() => useVersionUpdater());
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+
+    expect(result.current).toEqual({
+      latestVersion: "abcdef1234567890",
+      previousVersion: null,
+      latestShortVersion: "abcdef1",
+      previousShortVersion: null,
+      didChange: false,
+    });
+
+    vi.mocked(fetch).mockResolvedValue(
+      new Response("1234567890abcdef", {
+        status: 200,
+        headers: { "content-type": "text/plain" },
+      })
+    );
+
+    await act(async () => {
+      vi.advanceTimersByTime(pollIntervalMs);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(result.current.didChange).toBe(true);
+
+    expect(result.current).toEqual({
+      latestVersion: "1234567890abcdef",
+      previousVersion: "abcdef1234567890",
+      latestShortVersion: "1234567",
+      previousShortVersion: "abcdef1",
+      didChange: true,
+    });
+  });
+});

--- a/components/auth/useVersionUpdater.ts
+++ b/components/auth/useVersionUpdater.ts
@@ -5,9 +5,21 @@
  *--------------------------------------------*/
 import { useEffect, useEffectEvent, useState } from "react";
 
+/*--------------------------------------------*
+ * Internal Aliases
+ *--------------------------------------------*/
+import { getShortVersion } from "@lib/version";
+
+/*--------------------------------------------*
+ * Local Relative
+ *--------------------------------------------*/
+import { useLeaderTab } from "./useLeaderTab";
+
 type VersionUpdateState = {
   latestVersion: string | null;
   previousVersion: string | null;
+  latestShortVersion: string | null;
+  previousShortVersion: string | null;
   didChange: boolean;
 };
 
@@ -17,9 +29,15 @@ const POLL_INTERVAL_MS =
   Number(process.env.NEXT_PUBLIC_VERSION_POLL_INTERVAL_SECONDS || "60") * 1000;
 
 export function useVersionUpdater(): VersionUpdateState {
+  const { isLeaderTab } = useLeaderTab({
+    enabled: true,
+    coordinationKey: "version-updater",
+  });
   const [state, setState] = useState<VersionUpdateState>({
     latestVersion: null,
     previousVersion: null,
+    latestShortVersion: null,
+    previousShortVersion: null,
     didChange: false,
   });
 
@@ -28,9 +46,12 @@ export function useVersionUpdater(): VersionUpdateState {
       const basePath = process.env.NEXT_PUBLIC_BASE_PATH || "";
       const response = await fetch(`${basePath}/version`, {
         cache: "no-store",
+        redirect: "manual",
       });
 
-      if (!response.ok) {
+      const contentType = response.headers.get("content-type") || "";
+
+      if (!response.ok || !contentType.startsWith("text/plain")) {
         setState((previousState) => ({
           ...previousState,
           didChange: false,
@@ -38,15 +59,28 @@ export function useVersionUpdater(): VersionUpdateState {
         return;
       }
 
-      const latestVersion = await response.text();
+      const latestVersion = (await response.text()).trim();
+
+      if (!latestVersion) {
+        setState((previousState) => ({
+          ...previousState,
+          didChange: false,
+        }));
+        return;
+      }
+
       const previousVersion = currentVersion;
       currentVersion = latestVersion;
+      const latestShortVersion = getShortVersion(latestVersion);
+      const previousShortVersion = previousVersion ? getShortVersion(previousVersion) : null;
 
       const didChange = previousVersion !== null && latestVersion !== previousVersion;
 
       setState({
         latestVersion,
         previousVersion,
+        latestShortVersion,
+        previousShortVersion,
         didChange,
       });
     } catch {
@@ -58,6 +92,10 @@ export function useVersionUpdater(): VersionUpdateState {
   });
 
   useEffect(() => {
+    if (!isLeaderTab) {
+      return;
+    }
+
     void checkVersion();
 
     const intervalId = window.setInterval(() => {
@@ -67,7 +105,7 @@ export function useVersionUpdater(): VersionUpdateState {
     return () => {
       window.clearInterval(intervalId);
     };
-  }, []);
+  }, [isLeaderTab]);
 
   return state;
 }

--- a/lib/middleware-config.ts
+++ b/lib/middleware-config.ts
@@ -48,6 +48,7 @@ const PUBLIC_ROUTES = [
   "/register", // User registratio (accessed via email link with userId)
   "/healthy", // Health check
   "/security", // Security settings (cached)
+  "/version", // Version text endpoint used by the client updater
   "/error", // Error pages
 ];
 
@@ -73,7 +74,7 @@ export const AUTH_FLOW_ROUTES = [
  * API routes that should not be processed by auth middleware
  * (Static assets and Next.js internals are already excluded by matcher)
  */
-export const API_ROUTES = ["/healthy", "/security", "/login"];
+export const API_ROUTES = ["/healthy", "/security", "/version", "/login"];
 
 /**
  * Check if a pathname matches or begins with any pattern in a list

--- a/proxy.test.ts
+++ b/proxy.test.ts
@@ -55,7 +55,7 @@ vi.mock("./lib/service-url", () => ({
 }));
 
 vi.mock("./lib/middleware-config", () => ({
-  API_ROUTES: ["/api", "/healthy", "/security", "/login", "/logout-session"],
+  API_ROUTES: ["/api", "/healthy", "/security", "/version", "/login", "/logout-session"],
   AUTH_FLOW_ROUTES: [
     "/password",
     "/password/reset",
@@ -107,6 +107,14 @@ describe("proxy middleware", () => {
       const request = makeRequest("/healthy");
       const response = await proxy(request);
 
+      expect(response.headers.get("Content-Security-Policy")).toBe("default-src 'self';");
+    });
+
+    it("allows the version endpoint to bypass auth redirects", async () => {
+      const request = makeRequest("/version");
+      const response = await proxy(request);
+
+      expect(response.status).toBe(200);
       expect(response.headers.get("Content-Security-Policy")).toBe("default-src 'self';");
     });
 


### PR DESCRIPTION
# Summary | Résumé

- Updates to only send heartbeats for the active tab
- Adds a version # debug current : prev to the dialog 