### PR TITLE
fix: alter log message to avoid alarm filter

### DIFF
--- a/app/(auth)/actions.ts
+++ b/app/(auth)/actions.ts
@@ -110,7 +110,7 @@ export const submitLoginForm = async (
     }
 
     // Always return generic error (don't reveal if user exists or password is wrong)
-    logMessage.info("Authentication failed, returning generic error");
+    logMessage.info("Authentication failed, returning generic message");
     return { error: t("validation.invalidCredentials") };
   }
 


### PR DESCRIPTION
# Summary 
Small adjustment to the log message so that it does not trigger CloudWatch alarms based on the `error` filter.
