### PR TITLE
chore: adjust VUs for ECS task size

### DIFF
--- a/test/perf/login.js
+++ b/test/perf/login.js
@@ -67,13 +67,10 @@ export const options = {
   scenarios: {
     login_flow: {
       executor: "ramping-vus",
-      startVUs: 1,
+      startVUs: 0,
       stages: [
-        { duration: "3m", target: 5 },
-        { duration: "3m", target: 10 },
-        { duration: "3m", target: 20 },
-        { duration: "3m", target: 10 },
-        { duration: "3m", target: 5 },
+        { duration: "1m", target: 5 },
+        { duration: "20m", target: 5 },
       ],
       gracefulRampDown: "30s",
       gracefulStop: "30s",


### PR DESCRIPTION
# Summary
Adjust k6 performance test to a 21 minute, 5VU test as this will fit the 4vCPU/8GB memory ECS task size. We can then create multiple ECS tasks running concurrently to test the target user load.

# Related
- https://github.com/cds-snc/platform-unified-accounts-user-portal/issues/265