### PR TITLE
fix: gradually ramp up load test

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,7 @@
   "features": {
     "ghcr.io/devcontainers/features/node:1": {
       "version": "24.15.0",
-      "pnpmVersion": "10.33.0"
+      "pnpmVersion": "11.0.8"
     },
     "ghcr.io/grafana/devcontainer-features/k6:1": {
       "version": "latest"

--- a/test/perf/login.js
+++ b/test/perf/login.js
@@ -69,8 +69,8 @@ export const options = {
       executor: "ramping-vus",
       startVUs: 0,
       stages: [
-        { duration: "1m", target: 5 },
-        { duration: "20m", target: 5 },
+        { duration: "5m", target: 5 },
+        { duration: "15m", target: 5 },
       ],
       gracefulRampDown: "30s",
       gracefulStop: "30s",


### PR DESCRIPTION
# Summary
Adjust the load test so that it gradually ramps up to 5 VUs and then maintains that load for 15 minutes.

This is being done to simulate a more realistic use scenario where load will build over time.
