### PR TITLE
Fix: Ensure custom headers are added to zitadel calls

### DIFF
--- a/lib/zitadel.ts
+++ b/lib/zitadel.ts
@@ -770,10 +770,26 @@ const loggingInterceptor = (next: AnyFn) => async (req: UnaryRequest | StreamReq
   return next(req);
 };
 
+const customHeaderInterceptor = (next: AnyFn) => async (req: UnaryRequest | StreamRequest) => {
+  if (process.env.CUSTOM_REQUEST_HEADERS) {
+    process.env.CUSTOM_REQUEST_HEADERS.split(",").forEach((header) => {
+      const kv = header.indexOf(":");
+      if (kv > 0) {
+        req.header.set(header.slice(0, kv).trim(), header.slice(kv + 1).trim());
+      } else {
+        logMessage.warn(
+          `Skipping malformed CUSTOM_REQUEST_HEADERS entry (expected key:value format)`
+        );
+      }
+    });
+  }
+  return next(req);
+};
+
 export function createServerTransport(token: string, baseUrl: string) {
   return libCreateServerTransport(token, {
     baseUrl,
-    interceptors: process.env.NODE_ENV === "development" ? [loggingInterceptor] : undefined,
+    interceptors: [customHeaderInterceptor, loggingInterceptor],
   });
 }
 


### PR DESCRIPTION
# Summary | Résumé
Ensures custom header is included on calls to Zitadel instance using RPC connect.