### PR TITLE
fix: cache of gRPC API responses

### DIFF
--- a/app/(auth)/mfa/set/verify/time-based/page.tsx
+++ b/app/(auth)/mfa/set/verify/time-based/page.tsx
@@ -12,7 +12,6 @@ import { AuthenticationMethodType } from "@zitadel/proto/zitadel/user/v2/user_se
 import { getOriginalHostFromHeaders } from "@lib/server/host";
 import { loadMfaVerificationSession } from "@lib/server/mfa-verify";
 import { resolveSiteConfigByHost } from "@lib/site-config";
-import { getSerializableObject } from "@lib/utils";
 import { getLoginSettings } from "@lib/zitadel";
 import { serverTranslation } from "@i18n/server";
 import { AuthPanel } from "@components/auth/AuthPanel";
@@ -38,7 +37,7 @@ export default async function Page() {
     redirect("/mfa/set/verify");
   }
 
-  const loginSettings = await getLoginSettings().then((obj) => getSerializableObject(obj));
+  const loginSettings = await getLoginSettings();
 
   return (
     <AuthPanel

--- a/app/(auth)/otp/time-based/page.tsx
+++ b/app/(auth)/otp/time-based/page.tsx
@@ -12,7 +12,7 @@ import { getSafeRedirectUrl } from "@lib/redirect-validator";
 import { getOriginalHostFromHeaders } from "@lib/server/host";
 import { loadSessionById, loadSessionByLoginname } from "@lib/session";
 import { resolveSiteConfigByHost } from "@lib/site-config";
-import { getSerializableObject, SearchParams } from "@lib/utils";
+import { SearchParams } from "@lib/utils";
 import { getLoginSettings } from "@lib/zitadel";
 import { serverTranslation } from "@i18n/server";
 import { AuthPanel } from "@components/auth/AuthPanel";
@@ -46,7 +46,7 @@ export default async function Page(props: { searchParams: Promise<SearchParams> 
 
   const safeRedirect = getSafeRedirectUrl(redirect);
 
-  const loginSettings = await getLoginSettings().then((obj) => getSerializableObject(obj));
+  const loginSettings = await getLoginSettings();
 
   return (
     <AuthPanel

--- a/app/(auth)/password/change/verify/time-based/page.tsx
+++ b/app/(auth)/password/change/verify/time-based/page.tsx
@@ -14,7 +14,6 @@ import { getOriginalHostFromHeaders } from "@lib/server/host";
 import { AuthLevel, checkAuthenticationLevel } from "@lib/server/route-protection";
 import { loadSessionById, loadSessionByLoginname } from "@lib/session";
 import { resolveSiteConfigByHost } from "@lib/site-config";
-import { getSerializableObject } from "@lib/utils";
 import { getLoginSettings } from "@lib/zitadel";
 import { serverTranslation } from "@i18n/server";
 import { AuthPanel } from "@components/auth/AuthPanel";
@@ -53,7 +52,7 @@ export default async function Page() {
     redirect("/password/change/verify");
   }
 
-  const loginSettings = await getLoginSettings().then((obj) => getSerializableObject(obj));
+  const loginSettings = await getLoginSettings();
 
   return (
     <AuthPanel

--- a/app/(auth)/password/reset/verify/time-based/page.tsx
+++ b/app/(auth)/password/reset/verify/time-based/page.tsx
@@ -13,7 +13,6 @@ import { getSessionCredentials } from "@lib/cookies";
 import { getOriginalHostFromHeaders } from "@lib/server/host";
 import { loadSessionById, loadSessionByLoginname } from "@lib/session";
 import { resolveSiteConfigByHost } from "@lib/site-config";
-import { getSerializableObject } from "@lib/utils";
 import { getLoginSettings } from "@lib/zitadel";
 import { serverTranslation } from "@i18n/server";
 import { AuthPanel } from "@components/auth/AuthPanel";
@@ -46,7 +45,7 @@ export default async function Page() {
     redirect("/password/reset/verify");
   }
 
-  const loginSettings = await getLoginSettings().then((obj) => getSerializableObject(obj));
+  const loginSettings = await getLoginSettings();
 
   return (
     <AuthPanel

--- a/lib/zitadel.ts
+++ b/lib/zitadel.ts
@@ -51,11 +51,11 @@ export async function getLoginSettings() {
   const settingsService = await getServiceForHost("SettingsService");
   return settingsService
     .getLoginSettings({ ctx: makeReqCtx(ZITADEL_ORGANIZATION) }, {})
-    .then((resp) => (resp.settings ? resp.settings : undefined));
+    .then((resp) => (resp.settings ? getSerializableObject(resp.settings) : undefined));
 }
 
 export async function getSerializableLoginSettings() {
-  const loginSettings = await getLoginSettings().then((obj) => getSerializableObject(obj));
+  const loginSettings = await getLoginSettings();
 
   if (!loginSettings) {
     throw new Error("No login settings found");
@@ -72,7 +72,7 @@ export async function getSecuritySettings() {
 
   return settingsService
     .getSecuritySettings({})
-    .then((resp) => (resp.settings ? resp.settings : undefined));
+    .then((resp) => (resp.settings ? getSerializableObject(resp.settings) : undefined));
 }
 
 export async function getLockoutSettings() {
@@ -82,7 +82,7 @@ export async function getLockoutSettings() {
   const settingsService = await getServiceForHost("SettingsService");
   return settingsService
     .getLockoutSettings({ ctx: makeReqCtx(ZITADEL_ORGANIZATION) }, {})
-    .then((resp) => (resp.settings ? resp.settings : undefined));
+    .then((resp) => (resp.settings ? getSerializableObject(resp.settings) : undefined));
 }
 
 /**
@@ -95,7 +95,7 @@ export async function getPasswordExpirySettings() {
   const settingsService = await getServiceForHost("SettingsService");
   return settingsService
     .getPasswordExpirySettings({ ctx: makeReqCtx(ZITADEL_ORGANIZATION) }, {})
-    .then((resp) => (resp.settings ? resp.settings : undefined));
+    .then((resp) => (resp.settings ? getSerializableObject(resp.settings) : undefined));
 }
 
 /**
@@ -107,7 +107,7 @@ export async function listIDPLinks({ userId }: { userId: string }) {
 
   const userService = await getServiceForHost("UserService");
 
-  return userService.listIDPLinks({ userId }, {});
+  return userService.listIDPLinks({ userId }, {}).then((resp) => getSerializableObject(resp));
 }
 
 /**


### PR DESCRIPTION
# Summary
The gRPC response from Zitadel is returning a protobuf object which fails to cache with the following error:

```
Only plain objects can be passed to Client Components from Server Components.
Uint8Array objects are not supported
```

By moving the getSerializableObject() call inside the `use cache` boundary, the non-serializable objects are removed from the gRPC response before React attempts to serialize and cache the response.
