### PR TITLE
fix: display error when no MFA for password reset

### DIFF
--- a/app/(auth)/password/reset/actions.test.ts
+++ b/app/(auth)/password/reset/actions.test.ts
@@ -1,9 +1,10 @@
 import { GCNotifyConnector } from "@gcforms/connectors";
+import { AuthenticationMethodType } from "@zitadel/proto/zitadel/user/v2/user_service_pb";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { getPasswordResetTemplate } from "@lib/emailTemplates";
 import { createSessionAndUpdateCookie } from "@lib/server/cookie";
-import { listUsers, passwordResetWithReturn } from "@lib/zitadel";
+import { listAuthenticationMethodTypes, listUsers, passwordResetWithReturn } from "@lib/zitadel";
 import { serverTranslation } from "@i18n/server";
 
 import { setupServerActionContext } from "../../../../test/helpers/serverAction";
@@ -33,6 +34,7 @@ vi.mock("@lib/server/cookie", () => ({
 }));
 
 vi.mock("@lib/zitadel", () => ({
+  listAuthenticationMethodTypes: vi.fn(),
   listUsers: vi.fn(),
   passwordResetWithReturn: vi.fn(),
 }));
@@ -74,6 +76,10 @@ describe("submitUserNameForm", () => {
           },
         },
       ],
+    } as never);
+
+    vi.mocked(listAuthenticationMethodTypes).mockResolvedValue({
+      authMethodTypes: [AuthenticationMethodType.TOTP],
     } as never);
 
     vi.mocked(passwordResetWithReturn).mockResolvedValue({

--- a/app/(auth)/password/reset/actions.ts
+++ b/app/(auth)/password/reset/actions.ts
@@ -7,6 +7,7 @@
 import { GCNotifyConnector } from "@gcforms/connectors";
 import { create } from "@zitadel/client";
 import { ChecksSchema } from "@zitadel/proto/zitadel/session/v2/session_service_pb";
+import { AuthenticationMethodType } from "@zitadel/proto/zitadel/user/v2/user_service_pb";
 
 /*--------------------------------------------*
  * Internal Aliases
@@ -15,7 +16,7 @@ import { getPasswordResetTemplate } from "@lib/emailTemplates";
 import { logMessage } from "@lib/logger";
 import { createSessionAndUpdateCookie } from "@lib/server/cookie";
 import { buildUrlWithRequestId } from "@lib/utils";
-import { listUsers, passwordResetWithReturn } from "@lib/zitadel";
+import { listAuthenticationMethodTypes, listUsers, passwordResetWithReturn } from "@lib/zitadel";
 import { serverTranslation } from "@i18n/server";
 type SendResetCodeCommand = {
   loginName: string;
@@ -64,6 +65,19 @@ export const submitUserNameForm = async (
 
   if (!emailVerified) {
     logMessage.info("Password reset requested for user with unverified email address");
+    return genericErrorResponse;
+  }
+
+  const response = await listAuthenticationMethodTypes({
+    userId: userId,
+  });
+
+  const authMethods = response.authMethodTypes ?? [];
+  const canUseTotp = authMethods.includes(AuthenticationMethodType.TOTP);
+  const canUseU2F = authMethods.includes(AuthenticationMethodType.U2F);
+
+  if (!canUseTotp && !canUseU2F) {
+    logMessage.info("Password reset recovery requires at least one strong MFA method");
     return genericErrorResponse;
   }
 

--- a/i18n/locales/fr.json
+++ b/i18n/locales/fr.json
@@ -129,7 +129,7 @@
     "registerLinkText": "en créer un maintenant",
     "form": {
       "label": "Adresse courriel",
-      "description": "Entrez votre propre adresse courriel individuelledu gouvernement.",
+      "description": "Entrez votre propre adresse courriel individuelle du gouvernement.",
       "passwordLabel": "Mot de passe",
       "forgotPasswordLink": "Vous avez oublié votre mot de passe?",
       "signingIn": "Connexion en cours...",


### PR DESCRIPTION
# Summary
Update the password reset flow to display an error message when it is not possible for a password to be reset due to missing MFA.