### PR TITLE
fix: add WAF geo restriction bypass header

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -49,5 +49,6 @@ jobs:
           USERNAME: ${{ secrets.STAGING_INTEGRATION_TEST_USERNAME }}
           PASSWORD: ${{ secrets.STAGING_INTEGRATION_TEST_PASSWORD }}
           TOTP_SECRET: ${{ secrets.STAGING_INTEGRATION_TEST_TOTP_SECRET }}
+          WAF_GEO_RESTRICTION_BYPASS: ${{ secrets.STAGING_WAF_GEO_RESTRICTION_BYPASS }}
         run: 
           pnpm test:playwright

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -6,6 +6,9 @@ module.exports = defineConfig({
   expect: {
     timeout: 20000,
   },
+  extraHTTPHeaders: {
+    "waf-geo-restriction-bypass": `${process.env.WAF_GEO_RESTRICTION_BYPASS ?? ""}`,
+  },
   workers: 1,
   use: {
     headless: true,


### PR DESCRIPTION
# Summary
Add the header that will allow the integration tests to bypass the Canada-only geo restriction setup in Staging.

# Related
- https://github.com/cds-snc/platform-unified-accounts/pull/143
- https://github.com/cds-snc/platform-core-services/issues/993