### PR TITLE
fix: add element attributes for register integration test

### DIFF
--- a/.github/workflows/integration-test-staging.yml
+++ b/.github/workflows/integration-test-staging.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   integration-test:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    uses: ./.github/workflows/integration-test.yml
+    uses: cds-snc/platform-unified-accounts-user-portal/.github/workflows/integration-test.yml@278da63df4d9e5a2cae7495dfef753d3851ca0df
     with:
       idp_url: ${{ vars.STAGING_INTEGRATION_TEST_URL }}
     secrets:

--- a/.github/workflows/pr-review-deploy.yml
+++ b/.github/workflows/pr-review-deploy.yml
@@ -139,7 +139,7 @@ jobs:
 
   pr-integration-test:
     needs: pr-review-deploy
-    uses: ./.github/workflows/integration-test.yml
+    uses: cds-snc/platform-unified-accounts-user-portal/.github/workflows/integration-test.yml@278da63df4d9e5a2cae7495dfef753d3851ca0df
     with:
       idp_url: ${{ needs.pr-review-deploy.outputs.url }}ui/v2
     secrets:

--- a/app/(auth)/otp/time-based/components/TotpRegister.tsx
+++ b/app/(auth)/otp/time-based/components/TotpRegister.tsx
@@ -124,7 +124,7 @@ export function TotpRegister({ uri, loginName, requestId, checkAfter }: Props) {
             </Link>
             <CopyToClipboard value={uri}></CopyToClipboard>
           </div>
-          <form className="w-full" action={formAction}>
+          <form id="totp-form" className="w-full" action={formAction}>
             {!isPending && state.error && (
               <div className="py-4">
                 <Alert type={ErrorStatus.ERROR} focussable>

--- a/app/(auth)/register/components/RegisterForm.tsx
+++ b/app/(auth)/register/components/RegisterForm.tsx
@@ -89,7 +89,7 @@ export function RegisterForm({ requestId, siteConfig }: Props) {
   return (
     <>
       <ErrorSummary id="errorSummary" validationErrors={state.validationErrors} />
-      <form action={formAction} noValidate>
+      <form id="register-form" action={formAction} noValidate>
         <div className="mb-4 flex flex-col gap-4">
           <div className="gcds-input-wrapper">
             <Label className="required" htmlFor="firstname" required>

--- a/app/(auth)/u2f/set/components/ChooseSecondFactorToSetup.tsx
+++ b/app/(auth)/u2f/set/components/ChooseSecondFactorToSetup.tsx
@@ -45,7 +45,7 @@ export function ChooseSecondFactorToSetup({ checkAfter, requestId }: Props) {
 
   return (
     <>
-      <div className="grid w-full grid-cols-1 gap-5 pt-4">
+      <div id="mfa-select" className="grid w-full grid-cols-1 gap-5 pt-4">
         {/* Authentication App - TOTP */}
         <MethodOptionCard
           method="authenticator"
@@ -76,7 +76,12 @@ export function ChooseSecondFactorToSetup({ checkAfter, requestId }: Props) {
       </div>
 
       <div className="mt-8 flex justify-start">
-        <Button theme="primary" disabled={!selectedMethod} onClick={handleContinue}>
+        <Button
+          id="mfa-continue"
+          theme="primary"
+          disabled={!selectedMethod}
+          onClick={handleContinue}
+        >
           {t("set.continue") || "Continue"}
         </Button>
       </div>

--- a/app/(auth)/verify/components/VerifyEmailForm.tsx
+++ b/app/(auth)/verify/components/VerifyEmailForm.tsx
@@ -188,7 +188,7 @@ export function VerifyEmailForm({
       )}
 
       <div className="w-full">
-        <form action={formAction} noValidate>
+        <form id="verify-form" action={formAction} noValidate>
           <CodeEntry state={state} code={code ?? ""} className="mt-10" />
 
           <div className="mt-8 mb-6 flex items-center gap-4">

--- a/components/auth/password-validation/PasswordValidationForm.tsx
+++ b/components/auth/password-validation/PasswordValidationForm.tsx
@@ -131,7 +131,13 @@ export function PasswordValidationForm({
   return (
     <>
       <ErrorSummary id="errorSummary" validationErrors={state.validationErrors} />
-      <form className="w-full" action={formAction} noValidate onChange={() => setDirty(true)}>
+      <form
+        id="password-form"
+        className="w-full"
+        action={formAction}
+        noValidate
+        onChange={() => setDirty(true)}
+      >
         <div className="mb-4 grid grid-cols-1 gap-4 pt-4">
           {requireConfirmationCode && (
             <div className="gcds-input-wrapper">

--- a/components/mfa/MethodOptionCard.tsx
+++ b/components/mfa/MethodOptionCard.tsx
@@ -50,6 +50,7 @@ export function MethodOptionCard({
       role="button"
       tabIndex={0}
       onKeyDown={handleKeyDown}
+      data-type={method}
     >
       <div className="flex items-start justify-between gap-4">
         <div className="flex items-start gap-4">


### PR DESCRIPTION
# Summary
Update the pages and components that are part of the TOTP user registration flow to include id and data attributes that will be used by the Playwright integration tests.

Additionally this pins the shared integration test workflow to a commit SHA.

#  Related
- https://github.com/cds-snc/platform-core-services/issues/993