### PR TITLE
feat: upload failed integration test results to S3

### DIFF
--- a/.github/workflows/integration-test-staging.yml
+++ b/.github/workflows/integration-test-staging.yml
@@ -10,6 +10,7 @@ on:
       - main
 
 permissions:
+  id-token: write
   contents: read
 
 jobs:
@@ -17,6 +18,9 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     uses: ./.github/workflows/integration-test.yml
     with:
+      account_id: ${{ vars.STAGING_AWS_ACCOUNT_ID }}
+      account_region: ca-central-1
+      bucket_name: ${{ vars.STAGING_INTEGRATION_TEST_BUCKET_NAME }}
       idp_url: ${{ vars.STAGING_INTEGRATION_TEST_IDP_URL }}
       portal_url: ${{ vars.STAGING_INTEGRATION_TEST_PORTAL_URL }}
     secrets:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -3,6 +3,15 @@ name: Integration test
 on:
   workflow_call:
     inputs:
+      account_id:
+        required: true
+        type: string
+      account_region:
+        required: true
+        type: string
+      bucket_name:
+        required: true
+        type: string
       idp_url:
         required: true
         type: string
@@ -22,6 +31,7 @@ on:
         required: true
 
 permissions:
+  id-token: write
   contents: read
 
 jobs:
@@ -56,6 +66,7 @@ jobs:
           cache: pnpm
 
       - name: Run integration tests
+        id: test
         env:
           IDP_URL: ${{ inputs.idp_url }}
           PORTAL_URL: ${{ inputs.portal_url }}
@@ -66,3 +77,17 @@ jobs:
           ZITADEL_BEARER_TOKEN: ${{ secrets.zitadel_bearer_token }}
         run: 
           pnpm test:playwright
+
+      - name: Configure AWS credentials using OIDC
+        if: steps.test.outcome == 'failure'
+        uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6.1.1
+        with:
+          role-to-assume: arn:aws:iam::${{ inputs.account_id }}:role/platform-unified-accounts-integration-tests
+          role-session-name: IntegrationTests
+          aws-region: ${{ inputs.account_region }}
+
+      - name: Upload test results
+        if: steps.test.outcome == 'failure'
+        run: |
+          DATE=$(date +"%Y-%m-%d")
+          aws s3 cp ./test-results s3://${{ inputs.bucket_name }}/${DATE}/${{ github.run_id }} --recursive

--- a/.github/workflows/pr-review-deploy.yml
+++ b/.github/workflows/pr-review-deploy.yml
@@ -141,6 +141,9 @@ jobs:
     needs: pr-review-deploy
     uses: ./.github/workflows/integration-test.yml
     with:
+      account_id: ${{ vars.STAGING_AWS_ACCOUNT_ID }}
+      account_region: ca-central-1
+      bucket_name: ${{ vars.STAGING_INTEGRATION_TEST_BUCKET_NAME }}
       idp_url: ${{ vars.STAGING_INTEGRATION_TEST_IDP_URL }}
       portal_url: ${{ needs.pr-review-deploy.outputs.url }}ui/v2
     secrets:

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -11,6 +11,7 @@ module.exports = defineConfig({
   workers: 1,
   use: {
     headless: true,
+    screenshot: "only-on-failure",
     trace: "on-first-retry",
     extraHTTPHeaders: {
       "waf-geo-restriction-bypass": `${process.env.WAF_GEO_RESTRICTION_BYPASS ?? ""}`,


### PR DESCRIPTION
# Summary 
Upload screenshots and trace to S3 when an integration test run fails. The suggested GitHub artifacts pattern is not being used here because there are secrets that are part of our Playwright HTTP requests.

# 
# Related
- Closes https://github.com/cds-snc/platform-core-services/issues/993