### PR TITLE
fix: allow test result upload to run

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -79,7 +79,7 @@ jobs:
           pnpm test:playwright
 
       - name: Configure AWS credentials using OIDC
-        if: steps.test.outcome == 'failure'
+        if: failure() && steps.test.outcome == 'failure'
         uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6.1.1
         with:
           role-to-assume: arn:aws:iam::${{ inputs.account_id }}:role/platform-unified-accounts-integration-tests
@@ -87,7 +87,7 @@ jobs:
           aws-region: ${{ inputs.account_region }}
 
       - name: Upload test results
-        if: steps.test.outcome == 'failure'
+        if: failure() && steps.test.outcome == 'failure'
         run: |
           DATE=$(date +"%Y-%m-%d")
           aws s3 cp ./test-results s3://${{ inputs.bucket_name }}/${DATE}/${{ github.run_id }} --recursive


### PR DESCRIPTION
# Summary
Add a `failure()` check so that the Playwright test upload steps will run when the test step fails.
