### PR TITLE
fix: race condition in user registration

### DIFF
--- a/app/(auth)/register/actions.test.ts
+++ b/app/(auth)/register/actions.test.ts
@@ -1,11 +1,10 @@
 import { create } from "@zitadel/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { completeFlowOrGetUrl } from "@lib/client";
 import { createSessionAndUpdateCookie } from "@lib/server/cookie";
 import { validateAccountWithPassword } from "@lib/validationSchemas";
 import { checkEmailVerification } from "@lib/verify-helper";
-import { addHumanUser, getLoginSettings, getUserByID } from "@lib/zitadel";
+import { addHumanUser, getLoginSettings } from "@lib/zitadel";
 
 import { setupServerActionContext } from "../../../test/helpers/serverAction";
 
@@ -17,10 +16,6 @@ vi.mock("next/headers", () => ({
 
 vi.mock("@zitadel/client", () => ({
   create: vi.fn(),
-}));
-
-vi.mock("@lib/client", () => ({
-  completeFlowOrGetUrl: vi.fn(),
 }));
 
 vi.mock("@lib/server/cookie", () => ({
@@ -42,7 +37,6 @@ vi.mock("@lib/verify-helper", () => ({
 vi.mock("@lib/zitadel", () => ({
   addHumanUser: vi.fn(),
   getLoginSettings: vi.fn(),
-  getUserByID: vi.fn(),
 }));
 
 vi.mock("@i18n/server", () => ({
@@ -87,20 +81,6 @@ describe("registerUser", () => {
         },
       },
     } as never);
-
-    vi.mocked(getUserByID).mockResolvedValue({
-      user: {
-        type: {
-          case: "human",
-          value: {},
-        },
-      },
-    } as never);
-
-    vi.mocked(checkEmailVerification).mockReturnValue(undefined);
-    vi.mocked(completeFlowOrGetUrl).mockResolvedValue({
-      redirect: "/account?requestId=req-123",
-    } as never);
   });
 
   it("returns generic error when validation fails", async () => {
@@ -128,14 +108,6 @@ describe("registerUser", () => {
     expect(response).toEqual({ error: "translated:errors.couldNotCreateSession" });
   });
 
-  it("returns not-found error when created user cannot be fetched", async () => {
-    vi.mocked(getUserByID).mockResolvedValue({ user: undefined } as never);
-
-    const response = await registerUser(baseCommand);
-
-    expect(response).toEqual({ error: "translated:errors.userNotFound" });
-  });
-
   it("returns email verification redirect when required", async () => {
     vi.mocked(checkEmailVerification).mockReturnValue({
       redirect: "/verify?requestId=req-123",
@@ -144,34 +116,5 @@ describe("registerUser", () => {
     const response = await registerUser(baseCommand);
 
     expect(response).toEqual({ redirect: "/verify?requestId=req-123" });
-    expect(completeFlowOrGetUrl).not.toHaveBeenCalled();
-  });
-
-  it("completes flow with session when requestId exists", async () => {
-    const response = await registerUser(baseCommand);
-
-    expect(response).toEqual({ redirect: "/account?requestId=req-123" });
-    expect(completeFlowOrGetUrl).toHaveBeenCalledWith(
-      {
-        sessionId: "session-123",
-        requestId: "req-123",
-      },
-      "https://forms.example"
-    );
-  });
-
-  it("completes flow with loginName when requestId is missing", async () => {
-    const response = await registerUser({
-      ...baseCommand,
-      requestId: undefined,
-    });
-
-    expect(response).toEqual({ redirect: "/account?requestId=req-123" });
-    expect(completeFlowOrGetUrl).toHaveBeenCalledWith(
-      {
-        loginName: "person@canada.ca",
-      },
-      "https://forms.example"
-    );
   });
 });

--- a/app/(auth)/register/actions.ts
+++ b/app/(auth)/register/actions.ts
@@ -9,12 +9,11 @@ import { ChecksSchema } from "@zitadel/proto/zitadel/session/v2/session_service_
 /*--------------------------------------------*
  * Internal Aliases
  *--------------------------------------------*/
-import { completeFlowOrGetUrl } from "@lib/client";
 import { logMessage } from "@lib/logger";
 import { createSessionAndUpdateCookie } from "@lib/server/cookie";
 import { validateAccountWithPassword } from "@lib/validationSchemas";
 import { checkEmailVerification } from "@lib/verify-helper";
-import { addHumanUser, getLoginSettings, getUserByID } from "@lib/zitadel";
+import { addHumanUser, getLoginSettings } from "@lib/zitadel";
 import { serverTranslation } from "@i18n/server";
 type RegisterUserCommand = {
   email: string;
@@ -71,32 +70,7 @@ export async function registerUser(command: RegisterUserCommand) {
     return { error: t("errors.couldNotCreateSession") };
   }
 
-  const userResponse = await getUserByID(session?.factors?.user?.id);
-
-  if (!userResponse.user) {
-    logMessage.error("Failed to fetch user after registration");
-    return { error: t("errors.userNotFound") };
-  }
-
-  const humanUser =
-    userResponse.user.type.case === "human" ? userResponse.user.type.value : undefined;
-
-  const emailVerificationCheck = checkEmailVerification(session, humanUser, command.requestId);
-
-  if (emailVerificationCheck?.redirect) {
-    return emailVerificationCheck;
-  }
-
-  logMessage.info("User registered successfully");
-  return completeFlowOrGetUrl(
-    command.requestId && session.id
-      ? {
-          sessionId: session.id,
-          requestId: command.requestId,
-        }
-      : {
-          loginName: session.factors.user.loginName,
-        },
-    loginSettings?.defaultRedirectUri
-  );
+  // An undefined humanUser is passed as the newly created user will not have their
+  // email verified yet so the behaviour we want is to trigger the email verification flow.
+  return checkEmailVerification(session, undefined, command.requestId);
 }


### PR DESCRIPTION
# Summary
Remove the check for the newly created user's email verification status as it will always be unverified.

This simplifies the registration flow so that it always leads to email verification and removes the intermittent `User could not be found` errors being thrown by the `getUserByID` call.  Previous to this change, these are the logs showing the error:

```
# Successful getLoginSettings call
time=2026-05-21T13:50:45.451Z level=INFO msg="request served" request.user_id=357256007820902725 TraceID=6c627430749ea471e2e0d5164a5cbd0d SpanID=25385ac7a5a8ee13 stream=request version=v4.13.0 protocol=connect service=zitadel.settings.v2.SettingsService http_method=POST path=/zitadel.settings.v2.SettingsService/GetLoginSettings

# Failed getUserById  
time=2026-05-21T13:50:45.481Z level=WARN msg="User could not be found (QUERY-Dfbg2)"  request.user_id=357256007820902725 TraceID=6becb695bd6d8587213956fcda564f2e SpanID=c11370b97b6a9b0c stream=request version=v4.13.0 err.kind=NotFound err.message="User could not be found" err.id=QUERY-Dfbg2 err.parent="sql: no rows in result set" err.reportLocation.filePath=/home/runner/work/zitadel/zitadel/internal/query/user.go err.reportLocation.lineNumber=882 err.reportLocation.functionName=github.com/zitadel/zitadel/internal/query.scanUser
```

At this point, the user is presented with a generic "Could not register account" error but their account exists in Zitadel.  As a result, if they attempt to re-start the registration they are met with the same generic error because the email is already assigned. 

Note that this fix does not change the behaviour of a user with an unverified email successfully entering their username/password. They are returned to the email verification step and can complete their account setup.

# Related
- Closes https://github.com/cds-snc/platform-unified-accounts-user-portal/issues/237