### PR TITLE
fix: pass Log Analytics workspace ID and key secret

### DIFF
--- a/.github/workflows/integration-test-staging.yml
+++ b/.github/workflows/integration-test-staging.yml
@@ -24,6 +24,8 @@ jobs:
       idp_url: ${{ vars.STAGING_INTEGRATION_TEST_IDP_URL }}
       portal_url: ${{ vars.STAGING_INTEGRATION_TEST_PORTAL_URL }}
     secrets:
+      log_analytics_workspace_id: ${{ secrets.LOG_ANALYTICS_WORKSPACE_ID }}
+      log_analytics_workspace_key: ${{ secrets.LOG_ANALYTICS_WORKSPACE_KEY }}
       username: ${{ secrets.STAGING_INTEGRATION_TEST_USERNAME }}
       password: ${{ secrets.STAGING_INTEGRATION_TEST_PASSWORD }}
       totp_secret: ${{ secrets.STAGING_INTEGRATION_TEST_TOTP_SECRET }}

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -19,6 +19,10 @@ on:
         required: true
         type: string
     secrets:
+      log_analytics_workspace_id:
+        required: true
+      log_analytics_workspace_key:
+        required: true
       username:
         required: true
       password:
@@ -46,8 +50,8 @@ jobs:
         uses: cds-snc/dns-proxy-action@9ad793100229573be3f5ba78cc69ec523f2c8b7e # v1.1.0
         env:
           DNS_PROXY_FORWARDTOSENTINEL: "true"
-          DNS_PROXY_LOGANALYTICSWORKSPACEID: "${{ secrets.LOG_ANALYTICS_WORKSPACE_ID }}"
-          DNS_PROXY_LOGANALYTICSSHAREDKEY: "${{ secrets.LOG_ANALYTICS_WORKSPACE_KEY }}"
+          DNS_PROXY_LOGANALYTICSWORKSPACEID: "${{ secrets.log_analytics_workspace_id }}"
+          DNS_PROXY_LOGANALYTICSSHAREDKEY: "${{ secrets.log_analytics_workspace_key }}"
           DNS_PROXY_SAFELIST: "${{ vars.DNS_PROXY_SAFELIST }}"
           DNS_PROXY_WILDCARDGREEDY: "true"
 

--- a/.github/workflows/pr-review-deploy.yml
+++ b/.github/workflows/pr-review-deploy.yml
@@ -147,6 +147,8 @@ jobs:
       idp_url: ${{ vars.STAGING_INTEGRATION_TEST_IDP_URL }}
       portal_url: ${{ needs.pr-review-deploy.outputs.url }}ui/v2
     secrets:
+      log_analytics_workspace_id: ${{ secrets.LOG_ANALYTICS_WORKSPACE_ID }}
+      log_analytics_workspace_key: ${{ secrets.LOG_ANALYTICS_WORKSPACE_KEY }}
       username: ${{ secrets.STAGING_INTEGRATION_TEST_USERNAME }}
       password: ${{ secrets.STAGING_INTEGRATION_TEST_PASSWORD }}
       totp_secret: ${{ secrets.STAGING_INTEGRATION_TEST_TOTP_SECRET }}


### PR DESCRIPTION
# Summary 
Update the shared integration test workflow to accept the Log Analytics workspace ID and key secrets. These are used by the DNS proxy action.