### PR TITLE
fix: improve security of headers and cookies

### DIFF
--- a/lib/fingerprint.ts
+++ b/lib/fingerprint.ts
@@ -19,6 +19,8 @@ async function setFingerprintIdCookie(fingerprintId: string) {
     httpOnly: true,
     path: "/",
     maxAge: 31536000, // 1 year
+    sameSite: "strict",
+    secure: process.env.NODE_ENV === "production",
   });
 }
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -8,28 +8,33 @@ declare global {
 
 const securityHeaders = [
   {
-    key: "Strict-Transport-Security",
-    value: "max-age=63072000; includeSubDomains; preload",
+    key: "Cross-Origin-Opener-Policy",
+    value: "same-origin",
   },
   {
-    key: "X-Frame-Options",
-    value: "DENY",
+    key: "Cross-Origin-Resource-Policy",
+    value: "same-origin",
   },
   {
-    key: "X-Content-Type-Options",
-    value: "nosniff",
+    key: "Permissions-Policy",
+    value:
+      "camera=(), microphone=(), geolocation=(), payment=(), browsing-topics=(), usb=(), serial=(), hid=(), bluetooth=()",
   },
   {
     key: "Referrer-Policy",
     value: "strict-origin-when-cross-origin",
   },
   {
-    key: "Permissions-Policy",
-    value: "camera=(), microphone=(), geolocation=(), payment=(), browsing-topics=()",
+    key: "Strict-Transport-Security",
+    value: "max-age=63072000; includeSubDomains; preload",
   },
   {
-    key: "Cross-Origin-Opener-Policy",
-    value: "same-origin",
+    key: "X-Content-Type-Options",
+    value: "nosniff",
+  },
+  {
+    key: "X-Frame-Options",
+    value: "DENY",
   },
 ];
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -12,16 +12,24 @@ const securityHeaders = [
     value: "max-age=63072000; includeSubDomains; preload",
   },
   {
-    key: "X-XSS-Protection",
-    value: "1; mode=block",
-  },
-  {
     key: "X-Frame-Options",
     value: "DENY",
   },
   {
     key: "X-Content-Type-Options",
     value: "nosniff",
+  },
+  {
+    key: "Referrer-Policy",
+    value: "strict-origin-when-cross-origin",
+  },
+  {
+    key: "Permissions-Policy",
+    value: "camera=(), microphone=(), geolocation=(), payment=(), browsing-topics=()",
+  },
+  {
+    key: "Cross-Origin-Opener-Policy",
+    value: "same-origin",
   },
 ];
 

--- a/proxy.ts
+++ b/proxy.ts
@@ -13,7 +13,7 @@ export const config = {
      * - public folder files
      * - files with extensions (images, fonts, etc.)
      */
-    "/((?!_next/static|_next/image|favicon.ico|img/|.*\\.(?:svg|png|jpg|jpeg|gif|webp|woff2?|css|js)$).*)",
+    "/(.*)",
   ],
 };
 

--- a/proxy.ts
+++ b/proxy.ts
@@ -7,6 +7,12 @@ BigInt.prototype.toJSON = function () {
   return this.toString();
 };
 
+export const config = {
+  matcher: [
+    "/:path*", // Match all paths
+  ],
+};
+
 export async function proxy(request: NextRequest) {
   // Add the original URL as a header to all requests
   const requestHeaders = new Headers(request.headers);

--- a/proxy.ts
+++ b/proxy.ts
@@ -3,20 +3,6 @@ import { NextRequest, NextResponse } from "next/server";
 import { ZITADEL_ORGANIZATION } from "@root/constants/config";
 import { generateCSP, responseWithCSP } from "@lib/cspScripts";
 
-export const config = {
-  matcher: [
-    /*
-     * Match all request paths except:
-     * - _next/static (static files)
-     * - _next/image (image optimization)
-     * - favicon.ico (favicon file)
-     * - public folder files
-     * - files with extensions (images, fonts, etc.)
-     */
-    "/(.*)",
-  ],
-};
-
 BigInt.prototype.toJSON = function () {
   return this.toString();
 };

--- a/proxy.ts
+++ b/proxy.ts
@@ -13,7 +13,7 @@ export const config = {
      * - public folder files
      * - files with extensions (images, fonts, etc.)
      */
-    "/((?!_next/static|_next/image|favicon.ico|.*\\..*|img/).*)",
+    "/((?!_next/static|_next/image|favicon.ico|img/|.*\\.(?:svg|png|jpg|jpeg|gif|webp|woff2?|css|js)$).*)",
   ],
 };
 


### PR DESCRIPTION
# Summary
Update the HTTP headers and cookie settings to improve the portals security posture:

- `X-XSS-Protection` removed as it is deprecated and can cause vulnerabilities in otherwise secure browsers.
- `Referrer-Policy` added so that only the domain is sent as the referrer header.
- `Permissions-Policy` disables all listed browser features as they are not needed.
- `Cross-Origin-Opener-Policy` blocks cross-origin sites from opening the portal in a popup.
- `Cross-Origin-Resource-Policy` prevents assets from being embedded in an external site.

The fingerprint cookie changes enforce sameSite and HTTPS access.

Additionally this updates the proxy `matcher` to run on all requests as it is currently not setting CSPs on the root path. This will cause the proxy to run on all static file requests.

# Related
- https://github.com/cds-snc/platform-unified-accounts-user-portal/issues/246
- https://github.com/vercel/next.js/issues/86701