### PR TITLE
fix: disable prefetch for links with low click rate

### DIFF
--- a/app/(auth)/components/LoginForm.tsx
+++ b/app/(auth)/components/LoginForm.tsx
@@ -173,7 +173,7 @@ export function LoginForm({ requestId, session }: Props) {
 
             {/* Forgot password link */}
             <div className="mt-2">
-              <Link href={buildUrlWithRequestId("/password/reset", requestId)}>
+              <Link href={buildUrlWithRequestId("/password/reset", requestId)} prefetch={false}>
                 {t("form.forgotPasswordLink")}
               </Link>
             </div>

--- a/app/(auth)/components/SignIn.tsx
+++ b/app/(auth)/components/SignIn.tsx
@@ -63,7 +63,10 @@ export const SignIn = ({ requestId, registerLink, allSessions }: SignInProps) =>
       <p className="mt-10">
         {t("register")}
         &nbsp;
-        <Link href={registerLink}>{t("registerLinkText")}</Link>.
+        <Link href={registerLink} prefetch={false}>
+          {t("registerLinkText")}
+        </Link>
+        .
       </p>
     </>
   );

--- a/app/(auth)/otp/time-based/components/LoginTOTP.tsx
+++ b/app/(auth)/otp/time-based/components/LoginTOTP.tsx
@@ -86,7 +86,7 @@ export function LoginTOTP({
 
         <div className="mt-8 flex items-center gap-4">
           {supportLink && (
-            <Link href={supportLink}>
+            <Link href={supportLink} prefetch={false}>
               <I18n i18nKey="help" namespace="verify" />
             </Link>
           )}

--- a/app/(auth)/register/components/RegisterForm.tsx
+++ b/app/(auth)/register/components/RegisterForm.tsx
@@ -167,7 +167,9 @@ export function RegisterForm({ requestId }: Props) {
         {termsOfUseLink && (
           <p className="-mt-2 mb-10">
             {t("terms.agreement")}
-            <Link href={termsOfUseLink}>{t("terms.linkText")}</Link>
+            <Link href={termsOfUseLink} prefetch={false}>
+              {t("terms.linkText")}
+            </Link>
           </p>
         )}
 

--- a/app/(auth)/verify/components/VerifyEmailForm.tsx
+++ b/app/(auth)/verify/components/VerifyEmailForm.tsx
@@ -161,7 +161,7 @@ export function VerifyEmailForm({
               <I18n i18nKey="newCode" namespace="verify" />
             </Button>
             {supportLink && (
-              <Link href={supportLink}>
+              <Link href={supportLink} prefetch={false}>
                 <I18n i18nKey="help" namespace="verify" />
               </Link>
             )}


### PR DESCRIPTION
# Summary
Disable Next.js `<Link>` prefetch for prominent links that have a low likelihood of being clicked by users. It was noticed during performance testing that there were 1,000's of requests to these prefetched routes during the normal auth flow.

# Related
- Closes https://github.com/cds-snc/platform-unified-accounts-user-portal/issues/277