### PR TITLE
fix: add 5s timeout to Zitadel gRPC calls

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -92,8 +92,8 @@ jobs:
       - name: Upload test results
         if: failure() && steps.test.outcome == 'failure'
         run: |
-          curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-          unzip awscliv2.zip
-          sudo ./aws/install
           DATE=$(date +"%Y-%m-%d")
+          apt-get update && apt-get install -y unzip  
+          curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+          unzip awscliv2.zip && ./aws/install
           aws s3 cp ./test-results s3://${{ inputs.bucket_name }}/${DATE}/${{ github.run_id }} --recursive

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -92,5 +92,8 @@ jobs:
       - name: Upload test results
         if: failure() && steps.test.outcome == 'failure'
         run: |
+          curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+          unzip awscliv2.zip
+          sudo ./aws/install
           DATE=$(date +"%Y-%m-%d")
           aws s3 cp ./test-results s3://${{ inputs.bucket_name }}/${DATE}/${{ github.run_id }} --recursive

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -44,7 +44,6 @@ jobs:
     container:
       # Playwright Docker image tag must match the pnpm-lock.yaml pinned version
       image: mcr.microsoft.com/playwright:v1.60.0-noble@sha256:9bd26ad900bb5e0f4dee75839e957a89ae89c2b7ab1e76050e559790e946b948
-      options: --user 1001
     steps:
       - name: Audit DNS requests
         uses: cds-snc/dns-proxy-action@9ad793100229573be3f5ba78cc69ec523f2c8b7e # v1.1.0

--- a/lib/zitadel.ts
+++ b/lib/zitadel.ts
@@ -797,6 +797,7 @@ const customHeaderInterceptor = (next: AnyFn) => async (req: UnaryRequest | Stre
 export function createServerTransport(token: string, baseUrl: string) {
   return libCreateServerTransport(token, {
     baseUrl,
+    defaultTimeoutMs: 5000,
     interceptors: [customHeaderInterceptor, loggingInterceptor],
   });
 }


### PR DESCRIPTION
# Summary 
Add a timeout to the user portal's calls to Zitadel. This will cause failures due to IdP overloading to bubble back to the portal and give us visibility to the poor performance.

Note that the 5s value will be adjusted based on how it performs during tests.

This PR also fixes issues with the integration test workflow's upload of failed test artifacts.

# Related
- https://github.com/cds-snc/platform-unified-accounts-user-portal/issues/265