### PR TITLE
fix: adjust the gRPC max timeout

### DIFF
--- a/lib/zitadel.ts
+++ b/lib/zitadel.ts
@@ -797,7 +797,7 @@ const customHeaderInterceptor = (next: AnyFn) => async (req: UnaryRequest | Stre
 export function createServerTransport(token: string, baseUrl: string) {
   return libCreateServerTransport(token, {
     baseUrl,
-    defaultTimeoutMs: 5000,
+    defaultTimeoutMs: 10000,
     interceptors: [customHeaderInterceptor, loggingInterceptor],
   });
 }

--- a/test/perf/login.js
+++ b/test/perf/login.js
@@ -184,8 +184,8 @@ function generateCodeChallenge(verifier) {
  * Generate a random delay to simulate user think time.
  */
 function randomDelay() {
-  const minDelayMs = 1000;
-  const maxDelayMs = 3000;
+  const minDelayMs = 5000;
+  const maxDelayMs = 10000;
   return new Promise((resolve) => {
     const delayMs = Math.floor(Math.random() * (maxDelayMs - minDelayMs + 1)) + minDelayMs;
     setTimeout(resolve, delayMs);


### PR DESCRIPTION
# Summary
Increase the gRPC timeout as we were hitting it during performance testing.

This also increases the amount pause time between actions in the performance test to simulate a human user more accurately.