### PR TITLE
fix: set the PR envs Zitadel API URL

### DIFF
--- a/.github/workflows/pr-review-deploy.yml
+++ b/.github/workflows/pr-review-deploy.yml
@@ -114,7 +114,8 @@ jobs:
             "$REGISTRY_PREFIX/$IMAGE:pr-$PR_NUMBER-$GITHUB_SHA" \
             "$ROLE_ARN" \
             "${{ secrets.PR_REVIEW_ENV_SUBNET_IDS }}" \
-            "${{ secrets.PR_REVIEW_ENV_SECURITY_GROUP_IDS }}")
+            "${{ secrets.PR_REVIEW_ENV_SECURITY_GROUP_IDS }}" \
+            "${{ vars.STAGING_INTEGRATION_TEST_URL }}")
           echo "URL=$URL" >> $GITHUB_OUTPUT
 
       - name: PR comment

--- a/.github/workflows/scripts/pr-review-deploy.sh
+++ b/.github/workflows/scripts/pr-review-deploy.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-# Usage: pr-review-deploy.sh <function-name> <image-uri> <role-arn> <subnet-ids> <security-group-ids> 
+# Usage: pr-review-deploy.sh <function-name> <image-uri> <role-arn> <subnet-ids> <security-group-ids> <zitadel-api-url>
 # Outputs the function URL to stdout
 
 FUNCTION_NAME="$1"
@@ -9,6 +9,7 @@ IMAGE_URI="$2"
 ROLE_ARN="$3"
 SUBNET_IDS="$4"
 SECURITY_GROUP_IDS="$5"
+ZITADEL_API_URL="$6"
 
 if aws lambda get-function --function-name "$FUNCTION_NAME" > /dev/null 2>&1; then
   aws lambda update-function-code \
@@ -23,6 +24,7 @@ else
     --memory-size 2048 \
     --architectures "arm64" \
     --code "ImageUri=$IMAGE_URI" \
+    --environment "Variables={ZITADEL_API_URL=$ZITADEL_API_URL}" \
     --description "cds-snc/platform-unified-accounts-user-portal" \
     --vpc-config "SubnetIds=$SUBNET_IDS,SecurityGroupIds=$SECURITY_GROUP_IDS" > /dev/null 2>&1
 


### PR DESCRIPTION
# Summary
Hardcode the Zitadel API URL as a function environment variable. This is required because of our switch to ECS Service Connect which no longer allows the PR review Lambda function to resolve private ECS task IP addresses.
