### PR TITLE
fix: docker sbom and failure jobs

### DIFF
--- a/.github/workflows/docker-sbom.yml
+++ b/.github/workflows/docker-sbom.yml
@@ -18,7 +18,7 @@ jobs:
   docker-sbom:
     runs-on: ubuntu-24.04-arm
     permissions:
-      contents: read
+      contents: write
     steps:
       - name: Audit DNS requests
         uses: cds-snc/dns-proxy-action@9ad793100229573be3f5ba78cc69ec523f2c8b7e # v1.1.0

--- a/.github/workflows/docker-update-staging.yml
+++ b/.github/workflows/docker-update-staging.yml
@@ -36,7 +36,7 @@ jobs:
   docker-sbom:
     needs: docker-build
     permissions:
-      contents: read
+      contents: write
     uses: ./.github/workflows/docker-sbom.yml
     with:
       GITHUB_SHA: ${{ github.sha }}
@@ -70,7 +70,13 @@ jobs:
       - docker-deploy
       - docker-sbom
       - integration-test
-    if: always() && contains(needs.*.result, 'failure')
+    if: >-
+      always() && (
+        needs.docker-build.result == 'failure' ||
+        needs.docker-deploy.result == 'failure' ||
+        needs.docker-sbom.result == 'failure' ||
+        needs.integration-test.result == 'failure'
+      )
     permissions: {}
     uses: ./.github/workflows/workflow-failure.yml
     secrets:


### PR DESCRIPTION
# Summary
Update the permissions on the Docker SBOM step and make sure the workflow-failure job runs when there is a failure.

# Related
- #286 