### PR TITLE
fix: remove triggers from PR deploy

### DIFF
--- a/.github/workflows/pr-review-deploy.yml
+++ b/.github/workflows/pr-review-deploy.yml
@@ -5,9 +5,7 @@ on:
     branches:
       - main
     types:
-      - labeled
       - opened
-      - reopened
       - synchronize
 
 env:


### PR DESCRIPTION
# Summary 
Remove the triggers from the PR deploy that are not caused by a new commit being pushed.  These are causing failures when labels are updated on PRs with no new commit since the Docker image for the commit SHA already exists.
