### PR TITLE
fix: remove workflow_run status check

### DIFF
--- a/.github/workflows/docker-update-staging.yml
+++ b/.github/workflows/docker-update-staging.yml
@@ -74,7 +74,6 @@ jobs:
       always() && (
         needs.docker-build.result == 'failure' ||
         needs.docker-deploy.result == 'failure' ||
-        needs.docker-sbom.result == 'failure' ||
         needs.integration-test.result == 'failure'
       )
     permissions: {}

--- a/.github/workflows/workflow-failure.yml
+++ b/.github/workflows/workflow-failure.yml
@@ -15,7 +15,6 @@ permissions: {}
 jobs:
   on-failure:
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.conclusion == 'failure'
     env:
       WORKFLOW_NAME: "${{ github.event.workflow_run.name }}"
       WORKFLOW_URL: "${{ github.event.workflow_run.html_url }}"


### PR DESCRIPTION
# Summary
Remove the status check on `workflow_run` as the workflow is no longer called with this trigger.

This also removes a Slack notification on SBOM failure as this job can be flaky due to GitHub's availability issues.
