### PR TITLE
fix: adjust password validation max length message

### DIFF
--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -228,7 +228,7 @@
       "hasUppercase": "A capital letter",
       "hasLowercase": "A lowercase letter",
       "hasSymbol": "A symbol",
-      "maxLength": "Less than 50 characters",
+      "maxLength": "Less than 51 characters",
       "mustMatch": "The passwords must match.",
       "equals": "Passwords must match.",
       "matches": "Matches",

--- a/i18n/locales/fr.json
+++ b/i18n/locales/fr.json
@@ -233,7 +233,7 @@
       "hasUppercase": "Une lettre majuscule",
       "hasLowercase": "Une lettre minuscule",
       "hasSymbol": "Un symbole",
-      "maxLength": "Moins de 50 caractères",
+      "maxLength": "Moins de 51 caractères",
       "mustMatch": "Les mots de passe doivent correspondre.",
       "equals": "Confirmation du mot de passe correcte.",
       "matches": "Correspondance",


### PR DESCRIPTION
# Summary
Update the password validation maxLength error message to match the validation condition of 50 characters or less.
