### PR TITLE
feat: server side password validation

### DIFF
--- a/app/(auth)/password/change/action.ts
+++ b/app/(auth)/password/change/action.ts
@@ -11,14 +11,18 @@ import { ChecksSchema } from "@zitadel/proto/zitadel/session/v2/session_service_
  *--------------------------------------------*/
 import { AuthenticatedAction } from "@lib/actions/authenticated";
 import { changePassword, verifyPassword } from "@lib/server/password";
+import { validatePassword } from "@lib/validation/validationSchemas";
 
 export const changePasswordFormAction = AuthenticatedAction(async function changePasswordFormAction(
   session,
   password: string,
   requestId?: string
 ) {
-  if (typeof password !== "string") {
-    throw new Error("Invalid password string");
+  const validationResult = await validatePassword({ password } as {
+    [k: string]: FormDataEntryValue;
+  });
+  if (!validationResult.success) {
+    throw new Error("Invalid password");
   }
 
   await changePassword({

--- a/lib/validation/validationSchemas.ts
+++ b/lib/validation/validationSchemas.ts
@@ -174,6 +174,15 @@ export const validateCode = async (
   return v.safeParse(formValidationSchema, formEntries, { abortPipeEarly: true });
 };
 
+export const validatePassword = async (formEntries: { [k: string]: FormDataEntryValue }) => {
+  const formValidationSchema = v.pipe(
+    v.object({
+      ...passwordSchema({}),
+    })
+  );
+  return v.safeParse(formValidationSchema, formEntries, { abortPipeEarly: true });
+};
+
 export const validateTotpCode = async (formEntries: { [k: string]: FormDataEntryValue }) => {
   const formValidationSchema = v.pipe(
     v.object({


### PR DESCRIPTION
# Summary | Résumé

new `validatePassword` validates the password on the server side actually making sure the password is non-empty and ≤ 50 characters before sending it to Zitadel, matching the frontend