### PR TITLE
feat: validate username

### DIFF
--- a/app/(auth)/password/reset/actions.ts
+++ b/app/(auth)/password/reset/actions.ts
@@ -19,6 +19,7 @@ import { logMessage } from "@lib/logger";
 import { createSessionAndUpdateCookie } from "@lib/server/cookie";
 import { passwordResetWithCode, verifyPassword } from "@lib/server/password";
 import { buildUrlWithRequestId } from "@lib/utils";
+import { validateUsername } from "@lib/validation/validationSchemas";
 import { listAuthenticationMethodTypes, listUsers, passwordResetWithReturn } from "@lib/zitadel";
 import { serverTranslation } from "@i18n/server";
 
@@ -35,6 +36,12 @@ export const submitUserNameForm = async (
   const genericErrorResponse = {
     error: t("errors.couldNotSendResetLink"),
   };
+
+  const validationResult = await validateUsername({ username: command.loginName });
+  if (!validationResult.success) {
+    logMessage.warn("Server side validation failed for password reset username");
+    return genericErrorResponse;
+  }
 
   const users = await listUsers({
     loginName: command.loginName,


### PR DESCRIPTION
# Summary | Résumé

Server side validation for a blank, too-long, or non-gov-email address is rejected immediately with the generic "could not send reset link" error