### PR TITLE
feat: validate code

### DIFF
--- a/app/(auth)/password/reset/actions.ts
+++ b/app/(auth)/password/reset/actions.ts
@@ -19,7 +19,11 @@ import { logMessage } from "@lib/logger";
 import { createSessionAndUpdateCookie } from "@lib/server/cookie";
 import { passwordResetWithCode, verifyPassword } from "@lib/server/password";
 import { buildUrlWithRequestId } from "@lib/utils";
-import { validateUsername } from "@lib/validation/validationSchemas";
+import {
+  validateCode,
+  validatePassword,
+  validateUsername,
+} from "@lib/validation/validationSchemas";
 import { listAuthenticationMethodTypes, listUsers, passwordResetWithReturn } from "@lib/zitadel";
 import { serverTranslation } from "@i18n/server";
 
@@ -146,6 +150,18 @@ export const resetPassword = AuthenticatedAction(async function resetPassword(
   if (!code || !password) {
     throw new Error("Missing required properties to reset password");
   }
+
+  const passwordValidation = await validatePassword({ password } as {
+    [k: string]: FormDataEntryValue;
+  });
+  const codeValidation = await validateCode({ code } as {
+    [k: string]: FormDataEntryValue;
+  });
+  if (!passwordValidation.success || !codeValidation.success) {
+    logMessage.warn("Server side validation failed for password reset");
+    throw new Error("Invalid password or code");
+  }
+
   const changeResponse = await passwordResetWithCode({
     code,
     userId: session.factors.user.id,


### PR DESCRIPTION
# Summary | Résumé

Add server-side validation to `resetPassword`

Validates the new password and reset code before sending them to Zitadel, matching the  frontend