### PR TITLE
chore: Add code to continue oidc login

### DIFF
--- a/app/(auth)/actions.test.ts
+++ b/app/(auth)/actions.test.ts
@@ -4,6 +4,8 @@ import { ChecksSchema } from "@zitadel/proto/zitadel/session/v2/session_service_
 import { UserState } from "@zitadel/proto/zitadel/user/v2/user_pb";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { getSessionCookieById } from "@lib/cookies";
+import { loginWithOIDCAndSession } from "@lib/oidc";
 import { createSessionAndUpdateCookie } from "@lib/server/cookie";
 import { validateUsernameAndPassword } from "@lib/validation/validationSchemas";
 import {
@@ -14,13 +16,14 @@ import {
 import {
   getLockoutSettings,
   getLoginSettings,
+  getSession,
   getUserByID,
   listAuthenticationMethodTypes,
 } from "@lib/zitadel";
 
 import { setupServerActionContext } from "../../test/helpers/serverAction";
 
-import { submitLoginForm } from "./actions";
+import { continueOidcSessionSelection, submitLoginForm } from "./actions";
 
 vi.mock("next/headers", () => ({
   headers: vi.fn(),
@@ -33,6 +36,15 @@ vi.mock("@zitadel/client", () => ({
 vi.mock("@lib/server/cookie", () => ({
   createSessionAndUpdateCookie: vi.fn(),
   CreateSessionFailedError: class CreateSessionFailedError extends Error {},
+}));
+
+vi.mock("@lib/cookies", () => ({
+  getSessionCookieById: vi.fn(),
+  setSelectedSession: vi.fn(),
+}));
+
+vi.mock("@lib/oidc", () => ({
+  loginWithOIDCAndSession: vi.fn(),
 }));
 
 vi.mock("@lib/service-url", () => ({
@@ -52,6 +64,7 @@ vi.mock("@lib/verify-helper", () => ({
 vi.mock("@lib/zitadel", () => ({
   getLockoutSettings: vi.fn(),
   getLoginSettings: vi.fn(),
+  getSession: vi.fn(),
   getUserByID: vi.fn(),
   listAuthenticationMethodTypes: vi.fn(),
 }));
@@ -239,6 +252,68 @@ describe("submitLoginForm", () => {
     expect(createSessionAndUpdateCookie).toHaveBeenCalledWith({
       checks: { checks: "value" },
       requestId: command.requestId,
+    });
+  });
+
+  it("completes OIDC callback when a valid stored session is selected", async () => {
+    vi.mocked(getSessionCookieById).mockResolvedValue({
+      id: "session-123",
+      token: "token-123",
+      loginName: "person@canada.ca",
+      displayName: "Person",
+      userId: "user-123",
+      creationTs: "1",
+      expirationTs: "2",
+      changeTs: "3",
+    } as never);
+    vi.mocked(getSession).mockResolvedValue({
+      session: {
+        id: "session-123",
+        factors: {
+          user: {
+            id: "user-123",
+            loginName: "person@canada.ca",
+          },
+        },
+      },
+    } as never);
+    vi.mocked(loginWithOIDCAndSession).mockResolvedValue({
+      redirect: "https://forms.example.ca/api/auth/callback/gcForms",
+    } as never);
+
+    const response = await continueOidcSessionSelection("session-123", "oidc_req-123");
+
+    expect(getSessionCookieById).toHaveBeenCalledWith({ sessionId: "session-123" });
+    expect(getSession).toHaveBeenCalledWith("session-123", "token-123");
+    expect(loginWithOIDCAndSession).toHaveBeenCalledWith({
+      authRequest: "oidc_req-123",
+      sessionId: "session-123",
+      sessions: [
+        {
+          id: "session-123",
+          factors: {
+            user: {
+              id: "user-123",
+              loginName: "person@canada.ca",
+            },
+          },
+        },
+      ],
+      sessionCookies: [
+        {
+          id: "session-123",
+          token: "token-123",
+          loginName: "person@canada.ca",
+          displayName: "Person",
+          userId: "user-123",
+          creationTs: "1",
+          expirationTs: "2",
+          changeTs: "3",
+        },
+      ],
+    });
+    expect(response).toEqual({
+      redirect: "https://forms.example.ca/api/auth/callback/gcForms",
     });
   });
 });

--- a/app/(auth)/actions.ts
+++ b/app/(auth)/actions.ts
@@ -10,11 +10,12 @@ import { ChecksSchema } from "@zitadel/proto/zitadel/session/v2/session_service_
 import { UserState } from "@zitadel/proto/zitadel/user/v2/user_pb";
 
 import { AuthenticatedAction } from "@lib/actions/authenticated";
-import { setSelectedSession } from "@lib/cookies";
+import { getSessionCookieById, setSelectedSession } from "@lib/cookies";
 /*--------------------------------------------*
  * Internal Aliases
  *--------------------------------------------*/
 import { logMessage } from "@lib/logger";
+import { loginWithOIDCAndSession } from "@lib/oidc";
 import { createSessionAndUpdateCookie } from "@lib/server/cookie";
 import { isSessionValid } from "@lib/session";
 import { buildUrlWithRequestId } from "@lib/utils";
@@ -24,7 +25,7 @@ import {
   checkMFAFactors,
   checkPasswordChangeRequired,
 } from "@lib/verify-helper";
-import { getUserByID, listAuthenticationMethodTypes } from "@lib/zitadel";
+import { getSession, getUserByID, listAuthenticationMethodTypes } from "@lib/zitadel";
 import { parseZitadelError } from "@lib/zitadel-errors";
 import { serverTranslation } from "@i18n/server";
 
@@ -152,6 +153,27 @@ export const submitLoginForm = async (command: SubmitLoginCommand): Promise<{ er
 // Unauthenticated Action to ensure a user can select an existing non-active session
 export const setSession = async (sessionId: string) => {
   return setSelectedSession(sessionId);
+};
+
+export const continueOidcSessionSelection = async (sessionId: string, requestId: string) => {
+  await setSelectedSession(sessionId);
+
+  const sessionCookie = await getSessionCookieById({ sessionId }).catch(() => null);
+  if (!sessionCookie) {
+    return { error: "Session not found or invalid" };
+  }
+
+  const sessionResponse = await getSession(sessionCookie.id, sessionCookie.token).catch(() => null);
+  if (!sessionResponse?.session) {
+    return { error: "Session not found or invalid" };
+  }
+
+  return loginWithOIDCAndSession({
+    authRequest: requestId,
+    sessionId,
+    sessions: [sessionResponse.session],
+    sessionCookies: [sessionCookie],
+  });
 };
 
 export const checkActiveSession = AuthenticatedAction(async function checkActiveSession(session) {

--- a/app/(auth)/components/SignIn.tsx
+++ b/app/(auth)/components/SignIn.tsx
@@ -13,7 +13,7 @@ import { Cookie } from "@lib/cookies";
 import { buildUrlWithRequestId } from "@lib/utils";
 import { useTranslation } from "@i18n";
 
-import { checkActiveSession, setSession } from "../actions";
+import { checkActiveSession, continueOidcSessionSelection, setSession } from "../actions";
 
 /*--------------------------------------------*
  * Local Relative
@@ -32,17 +32,29 @@ export const SignIn = ({ requestId, registerLink, allSessions }: SignInProps) =>
   const router = useRouter();
   const searchParams = useSearchParams();
   const selectedSession = searchParams.get("session");
+  const selectedSessionQuery = (sessionId: string) =>
+    `?session=${sessionId}${requestId ? `&requestId=${requestId}` : ""}`;
 
   const selectSession = async (sessionId: string) => {
     if (sessionId !== "other") {
       await setSession(sessionId);
       const isValidSession = await checkActiveSession();
       if (isValidSession) {
+        if (requestId) {
+          const result = await continueOidcSessionSelection(sessionId, requestId);
+          if ("redirect" in result) {
+            window.location.assign(result.redirect);
+            return;
+          }
+
+          return router.push(selectedSessionQuery(sessionId));
+        }
+
         return router.push(buildUrlWithRequestId("/account", requestId));
       }
     }
     // Used to set state on the page not as the result of a mutation action
-    router.push(`?session=${sessionId}${requestId ? `&requestId=${requestId}` : ""}`);
+    router.push(selectedSessionQuery(sessionId));
   };
 
   return (

--- a/app/(auth)/components/SignIn.tsx
+++ b/app/(auth)/components/SignIn.tsx
@@ -42,14 +42,18 @@ export const SignIn = ({ requestId, registerLink, allSessions }: SignInProps) =>
       if (isValidSession) {
         if (requestId) {
           const result = await continueOidcSessionSelection(sessionId, requestId);
+
           if ("redirect" in result) {
+            // If a redirect is provided, redirect to the specified URL
             window.location.assign(result.redirect);
             return;
           }
 
+          // If no redirect is provided, redirect to the selected session page
           return router.push(selectedSessionQuery(sessionId));
         }
 
+        // If no requestId is provided, redirect to the account page
         return router.push(buildUrlWithRequestId("/account", requestId));
       }
     }


### PR DESCRIPTION
# Summary | Résumé

This PR adds code to continue the OIDC login flow after an account is selected if a request Id exist.

## Issue

After selecting an account the OIDC login doesn't redirect back to the requesting app --- it always lands on account.

## Issue demo --- should redirect but doesn't

https://github.com/user-attachments/assets/dfb59fae-929e-44c5-84f3-8d44235b231d


## Current App (GC Forms) -- redirects but can't select an account

https://github.com/user-attachments/assets/9747bcba-29de-4f13-9f4e-c91c8570a2a0



## Upcoming GC Forms App PR

with  `prompt: "select_account"` 

https://github.com/cds-snc/platform-forms-client/pull/7562


