### PR TITLE
bug: fix for 404 error page on reset password

### DIFF
--- a/lib/server/loginname.test.ts
+++ b/lib/server/loginname.test.ts
@@ -214,7 +214,7 @@ describe("sendLoginname", () => {
     });
 
     describe("Single authentication method", () => {
-      test("should redirect to /password when user has only password and it is allowed", async () => {
+      test("should redirect to /password/change when user has only password and it is allowed", async () => {
         mockListAuthenticationMethodTypes.mockResolvedValue({
           authMethodTypes: [AuthenticationMethodType.PASSWORD],
         });
@@ -225,7 +225,7 @@ describe("sendLoginname", () => {
         });
 
         expect(result).toHaveProperty("redirect");
-        expect((result as WithRedirect).redirect).toMatch(/^\/password\?/);
+        expect((result as WithRedirect).redirect).toMatch(/^\/password\/change\?/);
         expect((result as WithRedirect).redirect).toContain("loginName=user%40example.com");
         expect((result as WithRedirect).redirect).toContain("requestId=req123");
       });
@@ -349,7 +349,7 @@ describe("sendLoginname", () => {
         expect(result).toEqual({ redirect: "https://idp.example.com/auth" });
       });
 
-      test("should redirect to /password when only password is available and allowed", async () => {
+      test("should redirect to /password/change when only password is available and allowed", async () => {
         mockGetLoginSettings.mockResolvedValue({ allowUsernamePassword: true });
         mockListAuthenticationMethodTypes.mockResolvedValue({
           authMethodTypes: [AuthenticationMethodType.PASSWORD],
@@ -358,7 +358,7 @@ describe("sendLoginname", () => {
         const result = await sendLoginname({ loginName: "user@example.com" });
 
         expect(result).toHaveProperty("redirect");
-        expect((result as WithRedirect).redirect).toMatch(/^\/password\?/);
+        expect((result as WithRedirect).redirect).toMatch(/^\/password\/change\?/);
       });
 
       test("should return error when password is available but allowUsernamePassword is false", async () => {
@@ -430,7 +430,7 @@ describe("sendLoginname", () => {
       expect(result).toEqual({ redirect: "https://idp.example.com/auth" });
     });
 
-    test("should redirect to /password when ignoreUnknownUsernames is true", async () => {
+    test("should redirect to /password/change when ignoreUnknownUsernames is true", async () => {
       mockGetLoginSettings.mockResolvedValue({ ignoreUnknownUsernames: true });
 
       const result = await sendLoginname({
@@ -439,7 +439,7 @@ describe("sendLoginname", () => {
       });
 
       expect(result).toHaveProperty("redirect");
-      expect((result as WithRedirect).redirect).toMatch(/^\/password\?/);
+      expect((result as WithRedirect).redirect).toMatch(/^\/password\/change\?/);
       expect((result as WithRedirect).redirect).toContain("loginName=user%40example.com");
       expect((result as WithRedirect).redirect).toContain("requestId=req123");
     });

--- a/lib/server/loginname.ts
+++ b/lib/server/loginname.ts
@@ -309,7 +309,7 @@ export async function sendLoginname(command: SendLoginnameCommand) {
           }
 
           return {
-            redirect: "/password?" + paramsPassword,
+            redirect: "/password/change?" + paramsPassword,
           };
 
         case AuthenticationMethodType.PASSKEY: // AuthenticationMethodType.AUTHENTICATION_METHOD_TYPE_PASSKEY
@@ -377,7 +377,7 @@ export async function sendLoginname(command: SendLoginnameCommand) {
         paramsPasswordDefault.append("organization", ZITADEL_ORGANIZATION);
 
         return {
-          redirect: "/password?" + paramsPasswordDefault,
+          redirect: "/password/change?" + paramsPasswordDefault,
         };
       }
     }
@@ -436,7 +436,7 @@ export async function sendLoginname(command: SendLoginnameCommand) {
 
     paramsPasswordDefault.append("organization", ZITADEL_ORGANIZATION);
 
-    return { redirect: "/password?" + paramsPasswordDefault };
+    return { redirect: "/password/change?" + paramsPasswordDefault };
   }
 
   logMessage.info("No valid login or registration path found, returning user not found");

--- a/lib/server/route-protection.test.ts
+++ b/lib/server/route-protection.test.ts
@@ -127,7 +127,7 @@ describe("route-protection", () => {
     await expect(checkAuthenticationLevel(AuthLevel.PASSWORD_REQUIRED)).rejects.toThrow(
       "NEXT_REDIRECT"
     );
-    expect(mockRedirect).toHaveBeenCalledWith("/password");
+    expect(mockRedirect).toHaveBeenCalledWith("/password/change");
   });
 
   it("satisfies any-mfa level after password verification", async () => {

--- a/lib/server/route-protection.ts
+++ b/lib/server/route-protection.ts
@@ -185,10 +185,10 @@ export async function checkAuthenticationLevel(
   if (requiredLevel === AuthLevel.PASSWORD_REQUIRED) {
     if (!factors.passwordVerified) {
       logMessage.debug(
-        `[Authentication Level] Required: ${requiredLevel}, Reason: Password not verified, Redirecting: "/password"`
+        `[Authentication Level] Required: ${requiredLevel}, Reason: Password not verified, Redirecting: "/password/change"`
       );
 
-      redirect(`/password${requestId ? `?requestId:${requestId}` : ""}`);
+      redirect(`/password/change${requestId ? `?requestId=${requestId}` : ""}`);
     }
     return session;
   }
@@ -197,17 +197,17 @@ export async function checkAuthenticationLevel(
   if (requiredLevel === AuthLevel.ANY_MFA_REQUIRED) {
     if (!factors.passwordVerified) {
       logMessage.debug(
-        `[Authentication Level] Required: ${requiredLevel}, Reason: Password not verified, Redirecting: "/password"`
+        `[Authentication Level] Required: ${requiredLevel}, Reason: Password not verified, Redirecting: "/password/change"`
       );
 
-      redirect(`/password${requestId ? `?requestId:${requestId}` : ""}`);
+      redirect(`/password/change${requestId ? `?requestId=${requestId}` : ""}`);
     }
     if (!hasAnyMFA(session)) {
       logMessage.debug(
-        `[Authentication Level] Required: ${requiredLevel}, Reason: MFA not verified, Redirecting: "/password"`
+        `[Authentication Level] Required: ${requiredLevel}, Reason: MFA not verified, Redirecting: "/password/change"`
       );
 
-      redirect(`/mfa${requestId ? `?requestId:${requestId}` : ""}`);
+      redirect(`/mfa${requestId ? `?requestId=${requestId}` : ""}`);
     }
 
     return session;
@@ -217,17 +217,17 @@ export async function checkAuthenticationLevel(
   if (requiredLevel === AuthLevel.STRONG_MFA_REQUIRED) {
     if (!factors.passwordVerified) {
       logMessage.debug(
-        `[Authentication Level] Required: ${requiredLevel}, Reason: Password not verified, Redirecting: "/password"`
+        `[Authentication Level] Required: ${requiredLevel}, Reason: Password not verified, Redirecting: "/password/change"`
       );
 
-      redirect(`/password${requestId ? `?requestId:${requestId}` : ""}`);
+      redirect(`/password/change${requestId ? `?requestId=${requestId}` : ""}`);
     }
     if (!hasStrongMFA(session)) {
       logMessage.debug(
-        `[Authentication Level] Required: ${requiredLevel}, Reason: Strong MFA not verified, Redirecting: "/password"`
+        `[Authentication Level] Required: ${requiredLevel}, Reason: Strong MFA not verified, Redirecting: "/password/change"`
       );
 
-      redirect(`/mfa${requestId ? `?requestId:${requestId}` : ""}`);
+      redirect(`/mfa${requestId ? `?requestId=${requestId}` : ""}`);
     }
     return session;
   }


### PR DESCRIPTION
# Summary | Résumé

- `loginname.ts` was redirecting to `/password?/loginName=` but the route does not exist, the actual page is `/password/change`
- Fixed to redirect to `/password/change`

# Related

bug/forgot-pass-404