### PR TITLE
fix: redirect user to root when password authentication required

### DIFF
--- a/lib/server/loginname.test.ts
+++ b/lib/server/loginname.test.ts
@@ -214,7 +214,7 @@ describe("sendLoginname", () => {
     });
 
     describe("Single authentication method", () => {
-      test("should redirect to /password/change when user has only password and it is allowed", async () => {
+      test("should redirect to / when user has only password and it is allowed", async () => {
         mockListAuthenticationMethodTypes.mockResolvedValue({
           authMethodTypes: [AuthenticationMethodType.PASSWORD],
         });
@@ -225,8 +225,7 @@ describe("sendLoginname", () => {
         });
 
         expect(result).toHaveProperty("redirect");
-        expect((result as WithRedirect).redirect).toMatch(/^\/password\/change\?/);
-        expect((result as WithRedirect).redirect).toContain("loginName=user%40example.com");
+        expect((result as WithRedirect).redirect).toMatch(/^\/\?/);
         expect((result as WithRedirect).redirect).toContain("requestId=req123");
       });
 
@@ -349,7 +348,7 @@ describe("sendLoginname", () => {
         expect(result).toEqual({ redirect: "https://idp.example.com/auth" });
       });
 
-      test("should redirect to /password/change when only password is available and allowed", async () => {
+      test("should redirect to / when only password is available and allowed", async () => {
         mockGetLoginSettings.mockResolvedValue({ allowUsernamePassword: true });
         mockListAuthenticationMethodTypes.mockResolvedValue({
           authMethodTypes: [AuthenticationMethodType.PASSWORD],
@@ -358,7 +357,7 @@ describe("sendLoginname", () => {
         const result = await sendLoginname({ loginName: "user@example.com" });
 
         expect(result).toHaveProperty("redirect");
-        expect((result as WithRedirect).redirect).toMatch(/^\/password\/change\?/);
+        expect((result as WithRedirect).redirect).toMatch(/^\/\??/);
       });
 
       test("should return error when password is available but allowUsernamePassword is false", async () => {
@@ -430,7 +429,7 @@ describe("sendLoginname", () => {
       expect(result).toEqual({ redirect: "https://idp.example.com/auth" });
     });
 
-    test("should redirect to /password/change when ignoreUnknownUsernames is true", async () => {
+    test("should redirect to / when ignoreUnknownUsernames is true", async () => {
       mockGetLoginSettings.mockResolvedValue({ ignoreUnknownUsernames: true });
 
       const result = await sendLoginname({
@@ -439,8 +438,7 @@ describe("sendLoginname", () => {
       });
 
       expect(result).toHaveProperty("redirect");
-      expect((result as WithRedirect).redirect).toMatch(/^\/password\/change\?/);
-      expect((result as WithRedirect).redirect).toContain("loginName=user%40example.com");
+      expect((result as WithRedirect).redirect).toMatch(/^\/\?/);
       expect((result as WithRedirect).redirect).toContain("requestId=req123");
     });
   });

--- a/lib/server/loginname.ts
+++ b/lib/server/loginname.ts
@@ -296,20 +296,8 @@ export async function sendLoginname(command: SendLoginnameCommand) {
             };
           }
 
-          const paramsPassword = new URLSearchParams({
-            loginName: session.factors?.user?.loginName,
-          });
-
-          // TODO: does this have to be checked in loginSettings.allowDomainDiscovery
-
-          paramsPassword.append("organization", ZITADEL_ORGANIZATION);
-
-          if (command.requestId) {
-            paramsPassword.append("requestId", command.requestId);
-          }
-
           return {
-            redirect: "/password/change?" + paramsPassword,
+            redirect: buildUrlWithRequestId("/", command.requestId),
           };
 
         case AuthenticationMethodType.PASSKEY: // AuthenticationMethodType.AUTHENTICATION_METHOD_TYPE_PASSKEY
@@ -366,18 +354,8 @@ export async function sendLoginname(command: SendLoginnameCommand) {
         }
 
         // user has no passkey setup and login settings allow passwords
-        const paramsPasswordDefault = new URLSearchParams({
-          loginName: session.factors?.user?.loginName,
-        });
-
-        if (command.requestId) {
-          paramsPasswordDefault.append("requestId", command.requestId);
-        }
-
-        paramsPasswordDefault.append("organization", ZITADEL_ORGANIZATION);
-
         return {
-          redirect: "/password/change?" + paramsPasswordDefault,
+          redirect: buildUrlWithRequestId("/", command.requestId),
         };
       }
     }
@@ -426,17 +404,7 @@ export async function sendLoginname(command: SendLoginnameCommand) {
 
   if (effectiveLoginSettings?.ignoreUnknownUsernames) {
     logMessage.debug("ignoreUnknownUsernames is set, redirecting to password");
-    const paramsPasswordDefault = new URLSearchParams({
-      loginName: command.loginName,
-    });
-
-    if (command.requestId) {
-      paramsPasswordDefault.append("requestId", command.requestId);
-    }
-
-    paramsPasswordDefault.append("organization", ZITADEL_ORGANIZATION);
-
-    return { redirect: "/password/change?" + paramsPasswordDefault };
+    return { redirect: buildUrlWithRequestId("/", command.requestId) };
   }
 
   logMessage.info("No valid login or registration path found, returning user not found");

--- a/lib/server/route-protection.test.ts
+++ b/lib/server/route-protection.test.ts
@@ -127,7 +127,7 @@ describe("route-protection", () => {
     await expect(checkAuthenticationLevel(AuthLevel.PASSWORD_REQUIRED)).rejects.toThrow(
       "NEXT_REDIRECT"
     );
-    expect(mockRedirect).toHaveBeenCalledWith("/password/change");
+    expect(mockRedirect).toHaveBeenCalledWith("/");
   });
 
   it("satisfies any-mfa level after password verification", async () => {

--- a/lib/server/route-protection.ts
+++ b/lib/server/route-protection.ts
@@ -185,10 +185,10 @@ export async function checkAuthenticationLevel(
   if (requiredLevel === AuthLevel.PASSWORD_REQUIRED) {
     if (!factors.passwordVerified) {
       logMessage.debug(
-        `[Authentication Level] Required: ${requiredLevel}, Reason: Password not verified, Redirecting: "/password/change"`
+        `[Authentication Level] Required: ${requiredLevel}, Reason: Password not verified, Redirecting: "/"`
       );
 
-      redirect(`/password/change${requestId ? `?requestId=${requestId}` : ""}`);
+      redirect(`/${requestId ? `?requestId=${requestId}` : ""}`);
     }
     return session;
   }
@@ -197,10 +197,10 @@ export async function checkAuthenticationLevel(
   if (requiredLevel === AuthLevel.ANY_MFA_REQUIRED) {
     if (!factors.passwordVerified) {
       logMessage.debug(
-        `[Authentication Level] Required: ${requiredLevel}, Reason: Password not verified, Redirecting: "/password/change"`
+        `[Authentication Level] Required: ${requiredLevel}, Reason: Password not verified, Redirecting: "/"`
       );
 
-      redirect(`/password/change${requestId ? `?requestId=${requestId}` : ""}`);
+      redirect(`/${requestId ? `?requestId=${requestId}` : ""}`);
     }
     if (!hasAnyMFA(session)) {
       logMessage.debug(
@@ -217,14 +217,14 @@ export async function checkAuthenticationLevel(
   if (requiredLevel === AuthLevel.STRONG_MFA_REQUIRED) {
     if (!factors.passwordVerified) {
       logMessage.debug(
-        `[Authentication Level] Required: ${requiredLevel}, Reason: Password not verified, Redirecting: "/password/change"`
+        `[Authentication Level] Required: ${requiredLevel}, Reason: Password not verified, Redirecting: "/"`
       );
 
-      redirect(`/password/change${requestId ? `?requestId=${requestId}` : ""}`);
+      redirect(`/${requestId ? `?requestId=${requestId}` : ""}`);
     }
     if (!hasStrongMFA(session)) {
       logMessage.debug(
-        `[Authentication Level] Required: ${requiredLevel}, Reason: Strong MFA not verified, Redirecting: "/password/change"`
+        `[Authentication Level] Required: ${requiredLevel}, Reason: Strong MFA not verified, Redirecting: "/mfa"`
       );
 
       redirect(`/mfa${requestId ? `?requestId=${requestId}` : ""}`);

--- a/lib/server/route-protection.ts
+++ b/lib/server/route-protection.ts
@@ -178,7 +178,7 @@ export async function checkAuthenticationLevel(
       `[Authentication Level] Required: ${requiredLevel}, Reason: ${factors.hasUser ? "Session expired" : "No user in session"}, Redirecting: "/"`
     );
 
-    redirect(`/${requestId ? `?requestId:${requestId}` : ""}`);
+    redirect(buildUrlWithRequestId("/", requestIdRef));
   }
 
   // Password required check
@@ -188,7 +188,7 @@ export async function checkAuthenticationLevel(
         `[Authentication Level] Required: ${requiredLevel}, Reason: Password not verified, Redirecting: "/"`
       );
 
-      redirect(`/${requestId ? `?requestId=${requestId}` : ""}`);
+      redirect(buildUrlWithRequestId("/", requestIdRef));
     }
     return session;
   }
@@ -200,14 +200,14 @@ export async function checkAuthenticationLevel(
         `[Authentication Level] Required: ${requiredLevel}, Reason: Password not verified, Redirecting: "/"`
       );
 
-      redirect(`/${requestId ? `?requestId=${requestId}` : ""}`);
+      redirect(buildUrlWithRequestId("/", requestIdRef));
     }
     if (!hasAnyMFA(session)) {
       logMessage.debug(
         `[Authentication Level] Required: ${requiredLevel}, Reason: MFA not verified, Redirecting: "/password/change"`
       );
 
-      redirect(`/mfa${requestId ? `?requestId=${requestId}` : ""}`);
+      redirect(buildUrlWithRequestId("/mfa", requestIdRef));
     }
 
     return session;
@@ -220,19 +220,19 @@ export async function checkAuthenticationLevel(
         `[Authentication Level] Required: ${requiredLevel}, Reason: Password not verified, Redirecting: "/"`
       );
 
-      redirect(`/${requestId ? `?requestId=${requestId}` : ""}`);
+      redirect(buildUrlWithRequestId("/", requestIdRef));
     }
     if (!hasStrongMFA(session)) {
       logMessage.debug(
         `[Authentication Level] Required: ${requiredLevel}, Reason: Strong MFA not verified, Redirecting: "/mfa"`
       );
 
-      redirect(`/mfa${requestId ? `?requestId=${requestId}` : ""}`);
+      redirect(buildUrlWithRequestId("/mfa", requestIdRef));
     }
     return session;
   }
   logMessage.error(
     `[Authentication Level] Required: ${requiredLevel}, Reason: Unknown auth level requested, Redirecting: "/"`
   );
-  redirect(`/${requestId ? `?requestId:${requestId}` : ""}`);
+  redirect(buildUrlWithRequestId("/", requestIdRef));
 }


### PR DESCRIPTION
# Summary
Update the `/password/change` redirects to `/` so that when password authentication is required the user is presented with the LoginForm and given the opportunity to enter their login details.

# Related
- https://github.com/cds-snc/platform-unified-accounts-user-portal/issues/326