### PR TITLE
fix: password reset redirect

### DIFF
--- a/app/(auth)/otp/time-based/actions.ts
+++ b/app/(auth)/otp/time-based/actions.ts
@@ -86,11 +86,14 @@ export const handleOTPFormSubmit = AuthenticatedAction(async function handleOTPF
 
   const redirectUrl = redirect ?? loginSettings?.defaultRedirectUri;
 
-  // Always include sessionId to ensure we load the exact session that was just updated
+  // Always include sessionId to ensure we load the exact session that was just updated.
+  // Do not forward an oidc_ requestId when an explicit redirect destination is set (e.g.
+  // "/password/reset/set" during password-reset MFA). Forwarding it would complete the
+  // OIDC auth flow immediately, bypassing the intermediate reset step entirely.
   const callbackResponse = await completeFlowAndRedirect(
     {
       sessionId: response.sessionId,
-      requestId: requestId,
+      requestId: redirect ? undefined : requestId,
     },
     redirectUrl
   );

--- a/lib/server/session.ts
+++ b/lib/server/session.ts
@@ -115,10 +115,13 @@ export async function continueWithSession({
   const targetRedirect = redirect || loginSettings?.defaultRedirectUri;
 
   if (requestId && session.id && session.factors?.user) {
+    // Do not forward an oidc_ requestId when an explicit redirect destination is set (e.g.
+    // "/password/reset/set" during password-reset MFA). Forwarding it would complete the
+    // OIDC auth flow immediately, bypassing the intermediate reset step entirely.
     return completeFlowAndRedirect(
       {
         sessionId: session.id,
-        requestId: requestId,
+        requestId: redirect ? undefined : requestId,
       },
       targetRedirect
     );


### PR DESCRIPTION
# Summary | Résumé

- Password reset broken when user arrived via OIDC login `requestId=oidc_`
- Fix: strip `requestId` before redirect when an explicit destination is already set.