### PR TITLE
fix: password reset as part of an OIDC auth flow

### DIFF
--- a/app/(auth)/password/reset/actions.ts
+++ b/app/(auth)/password/reset/actions.ts
@@ -145,7 +145,7 @@ export const submitUserNameForm = async (
 
 export const resetPassword = AuthenticatedAction(async function resetPassword(
   session,
-  { code, password }: { code?: string; password?: string }
+  { code, password, requestId }: { code?: string; password?: string; requestId?: string }
 ) {
   if (!code || !password) {
     throw new Error("Missing required properties to reset password");
@@ -176,5 +176,6 @@ export const resetPassword = AuthenticatedAction(async function resetPassword(
     checks: create(ChecksSchema, {
       password: { password },
     }),
+    requestId,
   });
 });

--- a/app/(auth)/password/reset/components/PasswordReset.tsx
+++ b/app/(auth)/password/reset/components/PasswordReset.tsx
@@ -16,8 +16,10 @@ import { Alert, ErrorStatus } from "@components/ui/form";
 import { resetPassword } from "../actions";
 export function PasswordReset({
   passwordComplexitySettings,
+  requestId,
 }: {
   passwordComplexitySettings?: PasswordComplexitySettings;
+  requestId?: string;
 }) {
   const { t } = useTranslation(["password"]);
   const [error, setError] = useState("");
@@ -29,9 +31,10 @@ export function PasswordReset({
   };
 
   const submitPasswordForm = async ({ password, code }: { password: string; code?: string }) => {
-    const payload: { password: string; code?: string } = {
+    const payload: { password: string; code?: string; requestId?: string } = {
       password,
       ...(code ? { code } : {}),
+      ...(requestId ? { requestId } : {}),
     };
 
     await resetPassword(payload).catch((e) => {

--- a/app/(auth)/password/reset/set/page.tsx
+++ b/app/(auth)/password/reset/set/page.tsx
@@ -50,7 +50,10 @@ export default async function Page(props: { searchParams: Promise<SearchParams> 
       descriptionI18nKey="reset.description"
       namespace="password"
     >
-      <PasswordReset passwordComplexitySettings={passwordComplexitySettings} />
+      <PasswordReset
+        passwordComplexitySettings={passwordComplexitySettings}
+        requestId={requestId}
+      />
     </AuthPanel>
   );
 }

--- a/lib/server/auth-flow.test.ts
+++ b/lib/server/auth-flow.test.ts
@@ -1,0 +1,196 @@
+import { mockRedirect } from "next/navigation";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { loginWithOIDCAndSession } from "@lib/oidc";
+
+import { completeFlowAndRedirect } from "./auth-flow";
+import { loadSessionsWithCookies } from "./session";
+
+/*--------------------------------------------*
+ * Mock all dependencies
+ *--------------------------------------------*/
+
+vi.mock("@lib/logger", () => ({
+  logMessage: {
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+vi.mock("@lib/oidc", () => ({
+  loginWithOIDCAndSession: vi.fn(),
+}));
+
+vi.mock("./session", () => ({
+  loadSessionsWithCookies: vi.fn(),
+}));
+
+/*--------------------------------------------*
+ * Helpers
+ *--------------------------------------------*/
+
+const SESSION_ID = "session-abc";
+const OIDC_REQUEST_ID = "oidc_auth-request-123";
+const NON_OIDC_REQUEST_ID = "saml_req-456";
+
+function setupSessionMock() {
+  vi.mocked(loadSessionsWithCookies).mockResolvedValue({
+    sessions: [],
+    sessionCookies: [],
+  } as never);
+}
+
+/*--------------------------------------------*
+ * Tests
+ *--------------------------------------------*/
+
+describe("completeFlowAndRedirect", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("non-OIDC flows", () => {
+    it("redirects to defaultRedirectUri when no requestId is provided", async () => {
+      await expect(
+        completeFlowAndRedirect({ sessionId: SESSION_ID }, "/some/path")
+      ).rejects.toThrow("NEXT_REDIRECT");
+
+      expect(mockRedirect).toHaveBeenCalledWith("/some/path");
+    });
+
+    it("redirects to /account when no requestId and no defaultRedirectUri", async () => {
+      await expect(completeFlowAndRedirect({ sessionId: SESSION_ID })).rejects.toThrow(
+        "NEXT_REDIRECT"
+      );
+
+      expect(mockRedirect).toHaveBeenCalledWith("/account");
+    });
+
+    it("redirects to defaultRedirectUri when requestId does not start with oidc_", async () => {
+      await expect(
+        completeFlowAndRedirect(
+          { sessionId: SESSION_ID, requestId: NON_OIDC_REQUEST_ID },
+          "/some/path"
+        )
+      ).rejects.toThrow("NEXT_REDIRECT");
+
+      expect(mockRedirect).toHaveBeenCalledWith("/some/path");
+    });
+
+    it("redirects to /account with requestId query param when no defaultRedirectUri and requestId is non-OIDC", async () => {
+      await expect(
+        completeFlowAndRedirect({ sessionId: SESSION_ID, requestId: NON_OIDC_REQUEST_ID })
+      ).rejects.toThrow("NEXT_REDIRECT");
+
+      expect(mockRedirect).toHaveBeenCalledWith(`/account?requestId=${NON_OIDC_REQUEST_ID}`);
+    });
+  });
+
+  describe("OIDC flows — normal completion", () => {
+    it("completes OIDC flow and redirects on success", async () => {
+      setupSessionMock();
+      vi.mocked(loginWithOIDCAndSession).mockResolvedValue({ redirect: "/callback" });
+
+      await expect(
+        completeFlowAndRedirect({ sessionId: SESSION_ID, requestId: OIDC_REQUEST_ID })
+      ).rejects.toThrow("NEXT_REDIRECT");
+
+      expect(loginWithOIDCAndSession).toHaveBeenCalledWith(
+        expect.objectContaining({
+          authRequest: "auth-request-123",
+          sessionId: SESSION_ID,
+        })
+      );
+      expect(mockRedirect).toHaveBeenCalledWith("/callback");
+    });
+
+    it("returns error when OIDC completion fails", async () => {
+      setupSessionMock();
+      vi.mocked(loginWithOIDCAndSession).mockResolvedValue({ error: "Auth failed" });
+
+      const result = await completeFlowAndRedirect({
+        sessionId: SESSION_ID,
+        requestId: OIDC_REQUEST_ID,
+      });
+
+      expect(result).toEqual({ error: "Auth failed" });
+      expect(mockRedirect).not.toHaveBeenCalled();
+    });
+
+    it("returns error when OIDC completion returns an unexpected result", async () => {
+      setupSessionMock();
+      vi.mocked(loginWithOIDCAndSession).mockResolvedValue(null as never);
+
+      const result = await completeFlowAndRedirect({
+        sessionId: SESSION_ID,
+        requestId: OIDC_REQUEST_ID,
+      });
+
+      expect(result).toEqual({ error: "Authentication completed but navigation failed" });
+    });
+  });
+
+  describe("OIDC flows — deferred completion (shouldDeferOIDCCompletion)", () => {
+    it("defers OIDC completion and redirects to /password/reset/set with requestId", async () => {
+      const redirectUri = "/password/reset/set";
+
+      await expect(
+        completeFlowAndRedirect({ sessionId: SESSION_ID, requestId: OIDC_REQUEST_ID }, redirectUri)
+      ).rejects.toThrow("NEXT_REDIRECT");
+
+      expect(mockRedirect).toHaveBeenCalledWith(`/password/reset/set?requestId=${OIDC_REQUEST_ID}`);
+      expect(loginWithOIDCAndSession).not.toHaveBeenCalled();
+    });
+
+    it("defers OIDC completion for /password/reset/set with a sub-path", async () => {
+      const redirectUri = "/password/reset/set/extra";
+
+      await expect(
+        completeFlowAndRedirect({ sessionId: SESSION_ID, requestId: OIDC_REQUEST_ID }, redirectUri)
+      ).rejects.toThrow("NEXT_REDIRECT");
+
+      expect(mockRedirect).toHaveBeenCalledWith(
+        `/password/reset/set/extra?requestId=${OIDC_REQUEST_ID}`
+      );
+      expect(loginWithOIDCAndSession).not.toHaveBeenCalled();
+    });
+
+    it("does NOT defer for a path that merely contains /password/reset/set", async () => {
+      setupSessionMock();
+      vi.mocked(loginWithOIDCAndSession).mockResolvedValue({ redirect: "/callback" });
+
+      // Path starts with /other — no deferral should occur
+      await expect(
+        completeFlowAndRedirect(
+          { sessionId: SESSION_ID, requestId: OIDC_REQUEST_ID },
+          "/other/password/reset/set"
+        )
+      ).rejects.toThrow("NEXT_REDIRECT");
+
+      expect(loginWithOIDCAndSession).toHaveBeenCalled();
+    });
+
+    it("does NOT defer when defaultRedirectUri is absent", async () => {
+      setupSessionMock();
+      vi.mocked(loginWithOIDCAndSession).mockResolvedValue({ redirect: "/callback" });
+
+      await expect(
+        completeFlowAndRedirect({ sessionId: SESSION_ID, requestId: OIDC_REQUEST_ID })
+      ).rejects.toThrow("NEXT_REDIRECT");
+
+      expect(loginWithOIDCAndSession).toHaveBeenCalled();
+    });
+
+    it("does NOT defer for an unrelated OIDC redirect path", async () => {
+      setupSessionMock();
+      vi.mocked(loginWithOIDCAndSession).mockResolvedValue({ redirect: "/callback" });
+
+      await expect(
+        completeFlowAndRedirect({ sessionId: SESSION_ID, requestId: OIDC_REQUEST_ID }, "/account")
+      ).rejects.toThrow("NEXT_REDIRECT");
+
+      expect(loginWithOIDCAndSession).toHaveBeenCalled();
+      expect(mockRedirect).toHaveBeenCalledWith("/callback");
+    });
+  });
+});

--- a/lib/server/auth-flow.ts
+++ b/lib/server/auth-flow.ts
@@ -27,6 +27,10 @@ export async function completeFlowAndRedirect(
 ) {
   // Complete OIDC flows directly with server action
   if (command.requestId && command.requestId.startsWith("oidc_")) {
+    if (defaultRedirectUri && shouldDeferOIDCCompletion(defaultRedirectUri)) {
+      redirect(buildUrlWithRequestId(defaultRedirectUri, command.requestId), "push");
+    }
+
     // This completes the flow and redirects to URL or returns error
     const result = await completeAuthFlow({
       sessionId: command.sessionId,
@@ -98,4 +102,16 @@ async function completeAuthFlow(command: {
 
   logMessage.warn("Auth flow received invalid requestId format");
   return { error: "Invalid request ID format" };
+}
+
+/**
+ * Checks if OIDC completion should be deferred based on a given redirect.
+ * Handles cases where the session is not yet fully established (e.g., during password reset).
+ *
+ * @param redirect
+ * @returns
+ */
+function shouldDeferOIDCCompletion(redirect: string): boolean {
+  const deferOidcPaths = ["/password/reset/set"];
+  return deferOidcPaths.some((path) => redirect.startsWith(path));
 }


### PR DESCRIPTION
# Summary
Allow a password reset to be performed that is part of an OIDC auth request flow from a relying party.

Without this fix, the completeAuthFlow call attempts to check if the user's session is valid, which is false during the `/password/reset` flow (only MFA has been validated). This catches the user in a loop where they are redirected back to `/` with no method to reset their password.

This bug only occurs during an OIDC auth request. Using `/password/reset` without a `requestId` parameter works as expected.

# Related
- Closes https://github.com/cds-snc/platform-core-services/issues/1039