### PR TITLE
fix: redirect back to MFA select for password change

### DIFF
--- a/app/(auth)/password/change/verify/time-based/page.tsx
+++ b/app/(auth)/password/change/verify/time-based/page.tsx
@@ -24,8 +24,8 @@ export default async function Page(props: { searchParams: Promise<SearchParams> 
 
   const session = await checkAuthenticationLevel(AuthLevel.PASSWORD_REQUIRED, requestId);
 
-  if (session.authMethods?.includes(AuthenticationMethodType.TOTP)) {
-    redirect(buildUrlWithRequestId("/password/change", requestId), "push");
+  if (!session.authMethods?.includes(AuthenticationMethodType.TOTP)) {
+    redirect(buildUrlWithRequestId("/password/change", requestId));
   }
 
   return (

--- a/app/(auth)/password/change/verify/u2f/page.tsx
+++ b/app/(auth)/password/change/verify/u2f/page.tsx
@@ -25,8 +25,8 @@ export default async function Page(props: { searchParams: Promise<SearchParams> 
 
   const session = await checkAuthenticationLevel(AuthLevel.PASSWORD_REQUIRED, requestId);
 
-  if (session.authMethods?.includes(AuthenticationMethodType.U2F)) {
-    redirect(buildUrlWithRequestId("/password/change", requestId), "push");
+  if (!session.authMethods?.includes(AuthenticationMethodType.U2F)) {
+    redirect(buildUrlWithRequestId("/password/change", requestId));
   }
 
   return (


### PR DESCRIPTION
# Summary
Update the logic gates in the U2F and TOTP `/password/change/verify` pages so they properly redirect a user back to the MFA select screen if they manage to end up on an MFA verify page and do not have the matching MFA method registered with their account.
