### PR TITLE
fix: add server-side validation for u2f and sessionId

### DIFF
--- a/app/(auth)/actions.ts
+++ b/app/(auth)/actions.ts
@@ -19,7 +19,7 @@ import { loginWithOIDCAndSession } from "@lib/oidc";
 import { createSessionAndUpdateCookie } from "@lib/server/cookie";
 import { isSessionValid } from "@lib/session";
 import { buildUrlWithRequestId } from "@lib/utils";
-import { validateUsernameAndPassword } from "@lib/validation/validationSchemas";
+import { validateSessionId, validateUsernameAndPassword } from "@lib/validation/validationSchemas";
 import {
   checkEmailVerification,
   checkMFAFactors,
@@ -152,6 +152,11 @@ export const submitLoginForm = async (command: SubmitLoginCommand): Promise<{ er
 
 // Unauthenticated Action to ensure a user can select an existing non-active session
 export const setSession = async (sessionId: string) => {
+  const validationResult = validateSessionId(sessionId);
+  if (!validationResult.success) {
+    logMessage.warn("Server side validation failed for sessionId");
+    return { error: "Invalid session ID" };
+  }
   return setSelectedSession(sessionId);
 };
 

--- a/app/(auth)/u2f/actions.ts
+++ b/app/(auth)/u2f/actions.ts
@@ -19,6 +19,7 @@ import { getActiveSessionCookie } from "@lib/cookies";
 import { setSessionAndUpdateCookie } from "@lib/server/cookie";
 import { updateSession } from "@lib/server/session";
 import { continueWithSession } from "@lib/server/session";
+import { validateRequestId, validateU2FLoginCommand } from "@lib/validation/validationSchemas";
 
 import { U2F_ERRORS } from "./u2f-errors";
 
@@ -34,6 +35,11 @@ export const verifyU2FLogin = AuthenticatedAction(async function verifyU2FLogin(
   _,
   { checks, requestId, redirect }: VerifyU2FLoginCommand
 ) {
+  const loginValidation = validateU2FLoginCommand({ requestId, redirect });
+  if (!loginValidation.success) {
+    return { error: U2F_ERRORS.SESSION_VERIFICATION_FAILED };
+  }
+
   const activeSessionCookie = await getActiveSessionCookie();
 
   // Actually verify the U2F credential by updating the session with the checks
@@ -52,7 +58,8 @@ export const verifyU2FLogin = AuthenticatedAction(async function verifyU2FLogin(
 
 export const updateSessionForU2FChallenge = AuthenticatedAction(
   async function updateSessionForU2FChallenge(_, requestId?: string) {
-    if (requestId && typeof requestId !== "string") {
+    const validationResult = validateRequestId(requestId);
+    if (!validationResult.success) {
       throw new Error("Invalid Parameters");
     }
     const session = await updateSession({

--- a/app/(auth)/u2f/set/actions.ts
+++ b/app/(auth)/u2f/set/actions.ts
@@ -13,6 +13,7 @@ import { AuthenticatedAction } from "@lib/actions/authenticated";
  * Internal Aliases
  *--------------------------------------------*/
 import { getOriginalHost } from "@lib/server/host";
+import { validateVerifyU2FCommand } from "@lib/validation/validationSchemas";
 import { registerU2F, verifyU2FRegistration } from "@lib/zitadel";
 
 import { U2F_ERRORS } from "../u2f-errors";
@@ -60,6 +61,11 @@ export const verifyU2F = AuthenticatedAction(async function verifyU2F(
   session,
   command: VerifyU2FCommand
 ) {
+  const validationResult = validateVerifyU2FCommand(command);
+  if (!validationResult.success) {
+    return { error: U2F_ERRORS.SESSION_VERIFICATION_FAILED };
+  }
+
   let passkeyName = command.passkeyName;
 
   if (!passkeyName) {

--- a/app/account/actions.ts
+++ b/app/account/actions.ts
@@ -14,11 +14,13 @@ import { AuthenticatedAction } from "@lib/actions/authenticated";
 import { logMessage } from "@lib/logger";
 import { logoutCurrentSession } from "@lib/server/session";
 import { SessionWithAuthData } from "@lib/session";
-import { validatePersonalDetails } from "@lib/validation/validationSchemas";
+import { validatePersonalDetails, validateU2fId } from "@lib/validation/validationSchemas";
 import { getU2FList, removeTOTP, removeU2F, updateHuman } from "@lib/zitadel";
 
 export const removeU2FAction = AuthenticatedAction(async (session, u2fId: string) => {
-  if (typeof u2fId !== "string") {
+  const validationResult = validateU2fId(u2fId);
+  if (!validationResult.success) {
+    logMessage.warn("Server side validation failed for u2fId");
     throw new Error("Invalid parameters");
   }
 

--- a/lib/validation/validationSchemas.ts
+++ b/lib/validation/validationSchemas.ts
@@ -64,52 +64,61 @@ export const passwordSchema = ({
   requiresSymbol?: boolean;
   requiresUppercase?: boolean;
 }) => ({
-  ...{
-    password: v.pipe(
-      v.string(),
-      v.trim(),
-      v.minLength(1, "requiredPassword"),
-      v.check((password) => !minLength || password.length >= minLength, "minLength"),
-      v.maxLength(50, "maxLength"),
-      v.check(
-        (password) => !requiresLowercase || containsLowerCaseCharacter(password),
-        "hasLowercase"
-      ),
-      v.check(
-        (password) => !requiresUppercase || containsUpperCaseCharacter(password),
-        "hasUppercase"
-      ),
-      v.check((password) => !requiresNumber || containsNumber(password), "hasNumber"),
-      v.check((password) => !requiresSymbol || containsSymbol(password), "hasSymbol")
+  password: v.pipe(
+    v.string(),
+    v.trim(),
+    v.minLength(1, "requiredPassword"),
+    v.check((password) => !minLength || password.length >= minLength, "minLength"),
+    v.maxLength(50, "maxLength"),
+    v.check(
+      (password) => !requiresLowercase || containsLowerCaseCharacter(password),
+      "hasLowercase"
     ),
-  },
+    v.check(
+      (password) => !requiresUppercase || containsUpperCaseCharacter(password),
+      "hasUppercase"
+    ),
+    v.check((password) => !requiresNumber || containsNumber(password), "hasNumber"),
+    v.check((password) => !requiresSymbol || containsSymbol(password), "hasSymbol")
+  ),
 });
 
 export const confirmPasswordSchema = () => ({
-  ...{
-    confirmPassword: v.pipe(
-      v.string(),
-      v.trim(),
-      v.minLength(1, "requiredConfirmPassword"),
-      v.maxLength(50, "maxLength")
-    ),
-  },
+  confirmPassword: v.pipe(
+    v.string(),
+    v.trim(),
+    v.minLength(1, "requiredConfirmPassword"),
+    v.maxLength(50, "maxLength")
+  ),
 });
 
 export const codeSchema = (min = 1, max = 10) => ({
-  ...{
-    code: v.pipe(v.string(), v.trim(), v.minLength(min, "required"), v.maxLength(max, "maxLength")),
-  },
+  code: v.pipe(v.string(), v.trim(), v.minLength(min, "required"), v.maxLength(max, "maxLength")),
+});
+
+const redirectURLSchema = () => ({
+  redirect: v.optional(v.nullable(v.pipe(v.string(), v.trim(), v.maxLength(500, "maxLength")))),
 });
 
 const requestIdSchema = () => ({
-  requestId: v.optional(v.pipe(v.string(), v.maxLength(200, "maxLength"))),
+  requestId: v.optional(v.pipe(v.string(), v.trim(), v.maxLength(200, "maxLength"))),
+});
+
+const sessionIdSchema = () => ({
+  sessionId: v.pipe(
+    v.string(),
+    v.trim(),
+    v.minLength(1, "required"),
+    v.maxLength(200, "maxLength")
+  ),
 });
 
 const totpCodeSchema = () => ({
-  ...{
-    code: v.pipe(v.string(), v.trim(), v.regex(/^\d{6}$/, "invalidCodeLength")),
-  },
+  code: v.pipe(v.string(), v.trim(), v.regex(/^\d{6}$/, "invalidCodeLength")),
+});
+
+const u2fIdSchema = () => ({
+  u2fId: v.pipe(v.string(), v.trim(), v.minLength(1, "required"), v.maxLength(200, "maxLength")),
 });
 
 // Shared "composed" validation functions using the above schemas
@@ -200,4 +209,50 @@ export const validatePersonalDetails = async (formEntries: { [k: string]: FormDa
     })
   );
   return v.safeParse(formValidationSchema, formEntries, { abortPipeEarly: true });
+};
+
+export const validateRequestId = (requestId: unknown) => {
+  return v.safeParse(requestIdSchema().requestId, requestId, { abortPipeEarly: true });
+};
+
+export const validateSessionId = (sessionId: unknown) => {
+  return v.safeParse(sessionIdSchema().sessionId, sessionId, { abortPipeEarly: true });
+};
+
+export const validateU2fId = (u2fId: unknown) => {
+  return v.safeParse(u2fIdSchema().u2fId, u2fId, { abortPipeEarly: true });
+};
+
+export const validateU2FLoginCommand = (command: unknown) => {
+  const schema = v.object({
+    ...requestIdSchema(),
+    ...redirectURLSchema(),
+  });
+  return v.safeParse(schema, command, { abortPipeEarly: true });
+};
+
+export const validateVerifyU2FCommand = (command: unknown) => {
+  const schema = v.object({
+    u2fId: u2fIdSchema().u2fId,
+    passkeyName: v.optional(v.pipe(v.string(), v.maxLength(200, "maxLength"))),
+    publicKeyCredential: v.object({
+      id: v.pipe(v.string(), v.minLength(1, "required"), v.maxLength(1400, "maxLength")),
+      rawId: v.pipe(v.string(), v.minLength(1, "required"), v.maxLength(1400, "maxLength")),
+      type: v.literal("public-key"),
+      response: v.object({
+        attestationObject: v.pipe(
+          v.string(),
+          v.minLength(1, "required"),
+          v.maxLength(11000, "maxLength")
+        ),
+        clientDataJSON: v.pipe(
+          v.string(),
+          v.minLength(1, "required"),
+          v.maxLength(2000, "maxLength")
+        ),
+      }),
+    }),
+    sessionId: sessionIdSchema().sessionId,
+  });
+  return v.safeParse(schema, command, { abortPipeEarly: true });
 };


### PR DESCRIPTION
# Summary
Add Valibot schemas for u2f commands and IDs in server-side actions.

This also removes the inconsistent use of the spread operator within some of our schemas.

# Related
- https://github.com/cds-snc/platform-unified-accounts-user-portal/issues/350
