### PR TITLE
fix: switch integration tests to private JWT auth

### DIFF
--- a/.github/workflows/docker-update-staging.yml
+++ b/.github/workflows/docker-update-staging.yml
@@ -62,7 +62,7 @@ jobs:
       password: ${{ secrets.STAGING_INTEGRATION_TEST_PASSWORD }}
       totp_secret: ${{ secrets.STAGING_INTEGRATION_TEST_TOTP_SECRET }}
       waf_geo_restriction_bypass: ${{ secrets.STAGING_WAF_GEO_RESTRICTION_BYPASS }}
-      zitadel_bearer_token: ${{ secrets.STAGING_INTEGRATION_TEST_ZITADEL_BEARER_TOKEN }}
+      zitadel_service_account_key: ${{ secrets.STAGING_INTEGRATION_TEST_ZITADEL_SERVICE_ACCOUNT_KEY }}
       
   workflow-failure:
     needs: 

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -28,7 +28,7 @@ on:
         required: true
       waf_geo_restriction_bypass:
         required: true
-      zitadel_bearer_token:
+      zitadel_service_account_key:
         required: true
 
 env:
@@ -76,7 +76,7 @@ jobs:
           PASSWORD: ${{ secrets.password }}
           TOTP_SECRET: ${{ secrets.totp_secret }}
           WAF_GEO_RESTRICTION_BYPASS: ${{ secrets.waf_geo_restriction_bypass }}
-          ZITADEL_BEARER_TOKEN: ${{ secrets.zitadel_bearer_token }}
+          ZITADEL_SERVICE_ACCOUNT_KEY: ${{ secrets.zitadel_service_account_key }}
         run: pnpm test:playwright
 
       - name: Configure AWS credentials using OIDC

--- a/.github/workflows/pr-review-deploy.yml
+++ b/.github/workflows/pr-review-deploy.yml
@@ -160,4 +160,4 @@ jobs:
       password: ${{ secrets.STAGING_INTEGRATION_TEST_PASSWORD }}
       totp_secret: ${{ secrets.STAGING_INTEGRATION_TEST_TOTP_SECRET }}
       waf_geo_restriction_bypass: ${{ secrets.STAGING_WAF_GEO_RESTRICTION_BYPASS }}
-      zitadel_bearer_token: ${{ secrets.STAGING_INTEGRATION_TEST_ZITADEL_BEARER_TOKEN }}
+      zitadel_service_account_key: ${{ secrets.STAGING_INTEGRATION_TEST_ZITADEL_SERVICE_ACCOUNT_KEY }}

--- a/test/playwright/register.totp.spec.ts
+++ b/test/playwright/register.totp.spec.ts
@@ -1,7 +1,12 @@
 import { expect, test } from "@playwright/test";
 
 import { generateTOTP, getRandomEmail, getRandomPassword, getRequiredEnv } from "./utils/utils";
-import { deleteUserById, getEmailVerificationCode, getUserIdByEmail } from "./utils/zitadel";
+import {
+  deleteUserById,
+  getEmailVerificationCode,
+  getUserIdByEmail,
+  getZitadelAccessToken,
+} from "./utils/zitadel";
 
 test.describe("register user flow", () => {
   let idpUrl = "";
@@ -9,19 +14,21 @@ test.describe("register user flow", () => {
   let password = "";
   let portalUrl = "";
   let userId = "";
-  let zitadelBearerToken = "";
+  let serviceAccountKey = "";
+  let accessToken = "";
 
-  test.beforeAll(() => {
+  test.beforeAll(async () => {
     idpUrl = getRequiredEnv("IDP_URL");
     email = getRandomEmail(getRequiredEnv("USERNAME"));
     password = getRandomPassword();
     portalUrl = getRequiredEnv("PORTAL_URL");
-    zitadelBearerToken = getRequiredEnv("ZITADEL_BEARER_TOKEN");
+    serviceAccountKey = getRequiredEnv("ZITADEL_SERVICE_ACCOUNT_KEY");
+    accessToken = await getZitadelAccessToken(serviceAccountKey, idpUrl);
   });
 
   test.afterAll(async () => {
     if (userId) {
-      await deleteUserById(userId, zitadelBearerToken, idpUrl);
+      await deleteUserById(userId, accessToken, idpUrl);
     }
   });
 
@@ -47,12 +54,8 @@ test.describe("register user flow", () => {
 
     // Email verify
     await expect(page.locator("#verify-form #code")).toBeVisible();
-    userId = await getUserIdByEmail(email, zitadelBearerToken, idpUrl);
-    const emailVerificationCode = await getEmailVerificationCode(
-      userId,
-      zitadelBearerToken,
-      idpUrl
-    );
+    userId = await getUserIdByEmail(email, accessToken, idpUrl);
+    const emailVerificationCode = await getEmailVerificationCode(userId, accessToken, idpUrl);
     await page.locator("#verify-form #code").fill(emailVerificationCode);
     await page.locator("#verify-form button[type='submit']").click();
 

--- a/test/playwright/utils/zitadel.ts
+++ b/test/playwright/utils/zitadel.ts
@@ -61,7 +61,10 @@ export async function getZitadelAccessToken(
 
   const response = await fetch(`${apiBaseUrl}/oauth/v2/token`, {
     method: "POST",
-    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      "waf-geo-restriction-bypass": process.env.WAF_GEO_RESTRICTION_BYPASS ?? "",
+    },
     body: new URLSearchParams({
       grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
       assertion: jwt,
@@ -70,9 +73,7 @@ export async function getZitadelAccessToken(
   });
 
   if (!response.ok) {
-    throw new Error(
-      `Failed to exchange JWT for access token: ${response.status} ${await response.text()}`
-    );
+    throw new Error(`Failed to exchange JWT for access token: ${response.status}`);
   }
 
   const data = (await response.json()) as { access_token: string };

--- a/test/playwright/utils/zitadel.ts
+++ b/test/playwright/utils/zitadel.ts
@@ -14,6 +14,7 @@ import {
   SendEmailCodeRequestSchema,
   UserService,
 } from "@zitadel/proto/zitadel/user/v2/user_service_pb.js";
+import { createSign } from "crypto";
 
 let userService: Client<typeof UserService>;
 
@@ -24,12 +25,12 @@ const addRequestHeaders = () => (next: AnyFn) => async (req: UnaryRequest | Stre
   return next(req);
 };
 
-function getUserService(bearerToken: string, apiBaseUrl: string): Client<typeof UserService> {
+function getUserService(accessToken: string, apiBaseUrl: string): Client<typeof UserService> {
   if (userService) {
     return userService;
   }
 
-  const transport = createServerTransport(bearerToken, {
+  const transport = createServerTransport(accessToken, {
     baseUrl: apiBaseUrl,
     interceptors: [addRequestHeaders()],
   });
@@ -39,12 +40,49 @@ function getUserService(bearerToken: string, apiBaseUrl: string): Client<typeof 
   return userService;
 }
 
-export async function getUserIdByEmail(
-  email: string,
-  bearerToken: string,
+export async function getZitadelAccessToken(
+  serviceAccountKey: string,
   apiBaseUrl: string
 ): Promise<string> {
-  const response = await getUserService(bearerToken, apiBaseUrl).listUsers({
+  const { userId, keyId, key } = JSON.parse(serviceAccountKey) as {
+    userId: string;
+    keyId: string;
+    key: string;
+  };
+
+  const now = Math.floor(Date.now() / 1000);
+  const header = Buffer.from(JSON.stringify({ alg: "RS256", kid: keyId })).toString("base64url");
+  const payload = Buffer.from(
+    JSON.stringify({ iss: userId, sub: userId, aud: apiBaseUrl, iat: now, exp: now + 300 })
+  ).toString("base64url");
+  const signingInput = `${header}.${payload}`;
+  const signature = createSign("RSA-SHA256").update(signingInput).sign(key, "base64url");
+  const jwt = `${signingInput}.${signature}`;
+
+  const response = await fetch(`${apiBaseUrl}/oauth/v2/token`, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+      assertion: jwt,
+      scope: "openid urn:zitadel:iam:org:project:id:zitadel:aud",
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to exchange JWT for access token: ${response.status}`);
+  }
+
+  const data = (await response.json()) as { access_token: string };
+  return data.access_token;
+}
+
+export async function getUserIdByEmail(
+  email: string,
+  accessToken: string,
+  apiBaseUrl: string
+): Promise<string> {
+  const response = await getUserService(accessToken, apiBaseUrl).listUsers({
     queries: [
       create(SearchQuerySchema, {
         query: {
@@ -68,10 +106,10 @@ export async function getUserIdByEmail(
 
 export async function getEmailVerificationCode(
   userId: string,
-  bearerToken: string,
+  accessToken: string,
   apiBaseUrl: string
 ): Promise<string> {
-  const response = await getUserService(bearerToken, apiBaseUrl).sendEmailCode(
+  const response = await getUserService(accessToken, apiBaseUrl).sendEmailCode(
     create(SendEmailCodeRequestSchema, {
       userId,
       verification: {
@@ -89,8 +127,8 @@ export async function getEmailVerificationCode(
   return verificationCode;
 }
 
-export async function deleteUserById(userId: string, bearerToken: string, apiBaseUrl: string) {
-  return getUserService(bearerToken, apiBaseUrl).deleteUser(
+export async function deleteUserById(userId: string, accessToken: string, apiBaseUrl: string) {
+  return getUserService(accessToken, apiBaseUrl).deleteUser(
     create(DeleteUserRequestSchema, {
       userId,
     })

--- a/test/playwright/utils/zitadel.ts
+++ b/test/playwright/utils/zitadel.ts
@@ -70,7 +70,9 @@ export async function getZitadelAccessToken(
   });
 
   if (!response.ok) {
-    throw new Error(`Failed to exchange JWT for access token: ${response.status}`);
+    throw new Error(
+      `Failed to exchange JWT for access token: ${response.status} ${await response.text()}`
+    );
   }
 
   const data = (await response.json()) as { access_token: string };


### PR DESCRIPTION
# Summary
Update the integration tests so they use the private JWT authentication flow to request a short lived access token rather than relying on a long lived static personal access token.
