### PR TITLE
fix: ensure verified email

### DIFF
--- a/app/(auth)/mfa/set/page.tsx
+++ b/app/(auth)/mfa/set/page.tsx
@@ -30,7 +30,9 @@ export async function generateMetadata(): Promise<Metadata> {
 export default async function Page(props: { searchParams: Promise<SearchParams> }) {
   const searchParams = await props.searchParams;
   const { requestId } = searchParams;
-  const session = await checkAuthenticationLevel(AuthLevel.PASSWORD_REQUIRED, requestId);
+  const session = await checkAuthenticationLevel(AuthLevel.PASSWORD_REQUIRED, requestId, {
+    requireEmailVerified: true,
+  });
 
   if (requiresStrongMfaSetupVerification(session)) {
     logMessage.debug({

--- a/lib/server/route-protection.test.ts
+++ b/lib/server/route-protection.test.ts
@@ -130,6 +130,25 @@ describe("route-protection", () => {
     expect(mockRedirect).toHaveBeenCalledWith("/");
   });
 
+  it("redirects to verify when email verification is required but missing", async () => {
+    vi.mocked(loadActiveSession).mockResolvedValue({
+      factors: {
+        user: { id: "user-123" },
+        password: { verifiedAt: {} },
+      },
+      requestId: "req-123",
+    } as never);
+    vi.mocked(checkSessionFactorValidity).mockReturnValue({ valid: true });
+
+    await expect(
+      checkAuthenticationLevel(AuthLevel.PASSWORD_REQUIRED, undefined, {
+        requireEmailVerified: true,
+      })
+    ).rejects.toThrow("NEXT_REDIRECT");
+
+    expect(mockRedirect).toHaveBeenCalledWith("/verify?requestId=req-123");
+  });
+
   it("satisfies any-mfa level after password verification", async () => {
     vi.mocked(loadActiveSession).mockResolvedValue({
       factors: {

--- a/lib/server/route-protection.ts
+++ b/lib/server/route-protection.ts
@@ -133,7 +133,8 @@ export function requiresStrongMfaSetupVerification(
  */
 export async function checkAuthenticationLevel(
   requiredLevel: AuthLevel,
-  requestId?: string
+  requestId?: string,
+  options?: { requireEmailVerified?: boolean }
 ): Promise<SessionWithAuthData> {
   const headerList = await headers();
   const pathname = headerList.get("x-current-path");
@@ -168,6 +169,14 @@ export async function checkAuthenticationLevel(
   if (!valid) {
     // Session is expired, user needs to login
     redirect(buildUrlWithRequestId("/", requestIdRef));
+  }
+
+  if (options?.requireEmailVerified && !session.emailVerified) {
+    logMessage.debug(
+      `[Authentication Level] Required: ${requiredLevel}, Reason: Email not verified, Redirecting: "/verify"`
+    );
+
+    redirect(buildUrlWithRequestId("/verify", requestIdRef));
   }
 
   // For password and MFA checks, verify session factors


### PR DESCRIPTION
# Summary | Résumé

## For discussion

Would it be better to add  emailVerified check to `requiresStrongMfaSetupVerification(` --- would avoid multiple redirects?

## This PR 

Adds an options param  options?: { requireEmailVerified?: boolean } to `checkAuthenticationLevel`  

This will allow us to check if the user has a verified email before reaching a page.

Given we already have password protected auth pages I opted to do the email check only on the `mfa/set` page.  The thinking being you need mfa to reach the auth'd pages and now you'll need a verified email to set your MFA so that ends up covering all the pages without too much extra noise for auth level checks.



