### PR TITLE
fix:obfuscate error in server action

### DIFF
--- a/lib/actions/authenticated.ts
+++ b/lib/actions/authenticated.ts
@@ -55,7 +55,7 @@ export const AuthenticatedAction = <Input extends unknown[], Return>(
         throw error;
       }
       logMessage.error(`AuthenticatedAction failure in ${action.name || "unknown"}`, error);
-      throw new Error("Unauthorized");
+      throw new Error("Error in server action");
     });
   };
 };


### PR DESCRIPTION
# Summary | Résumé
Obfuscate error returned from `AuthenticatedAction` wrapper to be a generic server action error instead of unauthorized.
Next actions do not return a different html status code on error, only the body of the response identifies if there was an error.  I don't believe this will impact rate limiting requests.
