### PR TITLE
fix: language toggle does not need a full render

### DIFF
--- a/components/ui/language-toggle/LanguageToggle.tsx
+++ b/components/ui/language-toggle/LanguageToggle.tsx
@@ -3,7 +3,6 @@
 /*--------------------------------------------*
  * Framework and Third-Party
  *--------------------------------------------*/
-import { useRouter } from "next/navigation";
 
 /*--------------------------------------------*
  * Internal Aliases
@@ -26,8 +25,6 @@ const LanguageToggle = () => {
 
   const displayLang = lang[toggledLang(currentLang)];
 
-  const router = useRouter();
-
   return (
     <div className="gcds-lang-toggle inline-block">
       <h2 className="sr-only" lang={currentLang}>
@@ -38,8 +35,9 @@ const LanguageToggle = () => {
         className="gcds-lang-toggle cursor-pointer border-none bg-transparent p-0 text-inherit underline hover:no-underline"
         lang={displayLang.abbr}
         onClick={() => {
-          changeLanguage(currentLang === "en" ? "fr" : "en");
-          router.refresh();
+          const requestedLang = currentLang === "en" ? "fr" : "en";
+          changeLanguage(requestedLang);
+          document.documentElement.lang = requestedLang;
         }}
       >
         <span>{displayLang.text}</span>


### PR DESCRIPTION
# Summary | Résumé
Using `router.refresh()` causes a full client side render of the react tree.  The way i18n is built into the SSO app we do not need to lose the react state and can instead just call the language switching functions that modifies the i18n context which will modify the text in child components.

