### PR TITLE
fix: only allow one Docker update at a time

### DIFF
--- a/.github/workflows/docker-update-staging.yml
+++ b/.github/workflows/docker-update-staging.yml
@@ -1,5 +1,9 @@
 name: Docker update Staging
 
+concurrency:
+  group: docker-update-staging
+  cancel-in-progress: false
+
 on:
   push:
     branches:


### PR DESCRIPTION
# Summary
Limit the number of Docker update workflows that can run to prevent deployments from being only partially completed.
