### PR TITLE
Fix: registration flow init

### DIFF
--- a/lib/server/flow-initiation.ts
+++ b/lib/server/flow-initiation.ts
@@ -149,7 +149,7 @@ export async function handleOIDCFlowInitiation(
   }
 
   if (authRequest && authRequest.prompt.includes(Prompt.CREATE)) {
-    const registerUrl = constructUrl(request, "/register");
+    const registerUrl = constructUrl(request, "/before-you-start");
     registerUrl.searchParams.set("requestId", oidcRequestId);
 
     if (organization) {

--- a/proxy.ts
+++ b/proxy.ts
@@ -27,5 +27,27 @@ export async function proxy(request: NextRequest) {
   // Add the current path so it can be read in lib functions / server components
   requestHeaders.set("x-current-path", request.nextUrl.pathname);
 
+  // Only proxy paths need to be rewritten to the ZITADEL backend
+  const proxyPaths = ["/.well-known/openid-configuration", "/oauth/", "/oidc/"];
+  const isMatched = proxyPaths.some((prefix) => request.nextUrl.pathname.startsWith(prefix));
+
+  if (isMatched) {
+    const backendZitadelInstance = process.env.ZITADEL_API_URL;
+    if (!backendZitadelInstance) {
+      // fail safe - process request that will return 404
+      return responseWithCSP(NextResponse.next({ request: { headers: requestHeaders } }), csp);
+    }
+    request.nextUrl.href = `${backendZitadelInstance}${request.nextUrl.pathname}${request.nextUrl.search}`;
+
+    // Set to correct new host and remove and cookies coming from client
+    requestHeaders.set("host", backendZitadelInstance);
+
+    return NextResponse.rewrite(request.nextUrl, {
+      request: {
+        headers: requestHeaders,
+      },
+    });
+  }
+
   return responseWithCSP(NextResponse.next({ request: { headers: requestHeaders } }), csp);
 }


### PR DESCRIPTION
# Summary | Résumé
Proxies requests meant for backend zitadel through the SSO portal.  This potentially allows for disabling any public access to the Zitadel backend.

Ensures that when a request is received with a prompt of "Create" that the correct page is shown.  Previous `register` would be routed but the intended page is `before-you-start`