### PR TITLE
chore: temporarily disable registration tests

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -77,7 +77,7 @@ jobs:
           TOTP_SECRET: ${{ secrets.totp_secret }}
           WAF_GEO_RESTRICTION_BYPASS: ${{ secrets.waf_geo_restriction_bypass }}
           ZITADEL_SERVICE_ACCOUNT_KEY: ${{ secrets.zitadel_service_account_key }}
-        run: pnpm test:playwright -- test/playwright/login.totp.spec.ts
+        run: pnpm test:playwright test/playwright/login.totp.spec.ts
 
       - name: Configure AWS credentials using OIDC
         if: failure() && steps.test.outcome == 'failure'

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -77,7 +77,7 @@ jobs:
           TOTP_SECRET: ${{ secrets.totp_secret }}
           WAF_GEO_RESTRICTION_BYPASS: ${{ secrets.waf_geo_restriction_bypass }}
           ZITADEL_SERVICE_ACCOUNT_KEY: ${{ secrets.zitadel_service_account_key }}
-        run: pnpm test:playwright
+        run: pnpm test:playwright -- test/playwright/login.totp.spec.ts
 
       - name: Configure AWS credentials using OIDC
         if: failure() && steps.test.outcome == 'failure'

--- a/.github/workflows/pr-review-deploy.yml
+++ b/.github/workflows/pr-review-deploy.yml
@@ -116,7 +116,7 @@ jobs:
             "$ROLE_ARN" \
             "${{ secrets.PR_REVIEW_ENV_SUBNET_IDS }}" \
             "${{ secrets.PR_REVIEW_ENV_SECURITY_GROUP_IDS }}" \
-            "${{ vars.STAGING_INTEGRATION_TEST_URL }}")
+            "${{ vars.STAGING_INTEGRATION_TEST_IDP_URL }}")
           echo "URL=$URL" >> $GITHUB_OUTPUT
 
       - name: PR comment


### PR DESCRIPTION
# Summary
Update the integration test so that only the login test is run. This is being done while we work on a way to provide the workflow a path to call the private Zitadel API.

# Related
- https://github.com/cds-snc/platform-unified-accounts/pull/276