### PR TITLE
fix: pass custom headers when proxying requests

### DIFF
--- a/lib/utils/headers.ts
+++ b/lib/utils/headers.ts
@@ -1,0 +1,14 @@
+import { logMessage } from "../logger";
+
+export function applyCustomRequestHeaders(headers: Headers, customRequestHeaders?: string) {
+  customRequestHeaders?.split(",").forEach((header) => {
+    const separatorIndex = header.indexOf(":");
+    if (separatorIndex > 0) {
+      headers.set(header.slice(0, separatorIndex).trim(), header.slice(separatorIndex + 1).trim());
+    } else {
+      logMessage.warn(
+        `Skipping malformed CUSTOM_REQUEST_HEADERS entry (expected key:value format)`
+      );
+    }
+  });
+}

--- a/lib/zitadel.ts
+++ b/lib/zitadel.ts
@@ -41,6 +41,7 @@ import {
 import { ZITADEL_ORGANIZATION } from "@root/constants/config";
 import { serverTranslation } from "@i18n/server";
 
+import { applyCustomRequestHeaders } from "./utils/headers";
 import { getUserAgent } from "./fingerprint";
 import { logMessage } from "./logger";
 import { getServiceForHost } from "./service";
@@ -779,18 +780,7 @@ const loggingInterceptor = (next: AnyFn) => async (req: UnaryRequest | StreamReq
 };
 
 const customHeaderInterceptor = (next: AnyFn) => async (req: UnaryRequest | StreamRequest) => {
-  if (process.env.CUSTOM_REQUEST_HEADERS) {
-    process.env.CUSTOM_REQUEST_HEADERS.split(",").forEach((header) => {
-      const kv = header.indexOf(":");
-      if (kv > 0) {
-        req.header.set(header.slice(0, kv).trim(), header.slice(kv + 1).trim());
-      } else {
-        logMessage.warn(
-          `Skipping malformed CUSTOM_REQUEST_HEADERS entry (expected key:value format)`
-        );
-      }
-    });
-  }
+  applyCustomRequestHeaders(req.header, process.env.CUSTOM_REQUEST_HEADERS);
   return next(req);
 };
 

--- a/proxy.test.ts
+++ b/proxy.test.ts
@@ -2,12 +2,13 @@
  * Framework and Third-Party
  *--------------------------------------------*/
 import { NextRequest } from "next/server";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 /*--------------------------------------------*
  * Internal Aliases
  *--------------------------------------------*/
 import { generateCSP } from "@lib/cspScripts";
+import { logMessage } from "@lib/logger";
 
 /*--------------------------------------------*
  * Local Relative
@@ -88,6 +89,10 @@ describe("proxy middleware", () => {
     vi.mocked(generateCSP).mockReturnValue({ csp: "default-src 'self';", nonce: "test-nonce" });
   });
 
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   describe("Content-Security-Policy headers", () => {
     it("sets CSP header on route responses", async () => {
       const request = makeRequest("/");
@@ -118,6 +123,34 @@ describe("proxy middleware", () => {
       expect(generateCSP).toHaveBeenCalledOnce();
       expect(response.headers.get("x-middleware-request-x-nonce")).toBe("test-nonce");
       expect(response.headers.get("x-middleware-override-headers")).toContain("x-nonce");
+    });
+  });
+
+  describe("Zitadel proxy headers", () => {
+    it("forwards custom request headers to the Zitadel backend", async () => {
+      vi.stubEnv("ZITADEL_API_URL", "https://zitadel.example.com");
+      vi.stubEnv(
+        "CUSTOM_REQUEST_HEADERS",
+        "x-custom-header: custom-value,authorization:Bearer token:with:colons"
+      );
+
+      const response = await proxy(makeRequest("/.well-known/openid-configuration"));
+
+      expect(response.headers.get("x-middleware-request-x-custom-header")).toBe("custom-value");
+      expect(response.headers.get("x-middleware-request-authorization")).toBe(
+        "Bearer token:with:colons"
+      );
+    });
+
+    it("skips malformed custom request headers", async () => {
+      vi.stubEnv("ZITADEL_API_URL", "https://zitadel.example.com");
+      vi.stubEnv("CUSTOM_REQUEST_HEADERS", "malformed-header");
+
+      await proxy(makeRequest("/.well-known/openid-configuration"));
+
+      expect(logMessage.warn).toHaveBeenCalledWith(
+        "Skipping malformed CUSTOM_REQUEST_HEADERS entry (expected key:value format)"
+      );
     });
   });
 });

--- a/proxy.ts
+++ b/proxy.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 
 import { ZITADEL_ORGANIZATION } from "@root/constants/config";
 import { generateCSP, responseWithCSP } from "@lib/cspScripts";
+import { applyCustomRequestHeaders } from "@lib/utils/headers";
 
 BigInt.prototype.toJSON = function () {
   return this.toString();
@@ -37,11 +38,10 @@ export async function proxy(request: NextRequest) {
       // fail safe - process request that will return 404
       return responseWithCSP(NextResponse.next({ request: { headers: requestHeaders } }), csp);
     }
+
+    applyCustomRequestHeaders(requestHeaders, process.env.CUSTOM_REQUEST_HEADERS);
+
     request.nextUrl.href = `${backendZitadelInstance}${request.nextUrl.pathname}${request.nextUrl.search}`;
-
-    // Set to correct new host and remove and cookies coming from client
-    requestHeaders.set("host", backendZitadelInstance);
-
     return NextResponse.rewrite(request.nextUrl, {
       request: {
         headers: requestHeaders,


### PR DESCRIPTION
# Summary
Update the proxy request to Zitadel so that it uses the same CUSTOM_REQUEST_HEADERS env var as the Zitadel API requests. This will make managing environment variables simpler between localhost and ECS deployments since Service Connect is used for SSO portal to IdP requests in ECS and does not use the primary Zitadel URL.
