### PR TITLE
fix: remove cds-snc.freshdesk.com as valid email domain

### DIFF
--- a/lib/validation/validators.ts
+++ b/lib/validation/validators.ts
@@ -30,7 +30,7 @@ export function lowerCaseValidator(value: string): boolean {
  */
 export const isValidGovEmail = (email: string): boolean => {
   const regex =
-    /^([a-zA-Z0-9!#$%&'*+-/=?^_`{|}~.]+(\+[a-zA-Z0-9!#$%&'*+-/=?^_`{|}~.]*)?)@((?:[a-zA-Z0-9-.]+\.gc\.ca|cds-snc\.freshdesk\.com)|(canada|cds-snc|elections|rcafinnovation|canadacouncil|nfb|debates-debats|invcanada|gg)\.ca)$/;
+    /^([a-zA-Z0-9!#$%&'*+-/=?^_`{|}~.]+(\+[a-zA-Z0-9!#$%&'*+-/=?^_`{|}~.]*)?)@((?:[a-zA-Z0-9-.]+\.gc\.ca)|(canada|cds-snc|elections|rcafinnovation|canadacouncil|nfb|debates-debats|invcanada|gg)\.ca)$/;
   return regex.test(email);
 };
 


### PR DESCRIPTION
# Summary
Remove the CDS Freshdesk email as a valid account email domain.
