### PR TITLE
make page title responsive on language toggle

### DIFF
--- a/app/(auth)/all-set/page.tsx
+++ b/app/(auth)/all-set/page.tsx
@@ -1,7 +1,6 @@
 /*--------------------------------------------*
  * Framework and Third-Party
  *--------------------------------------------*/
-import { Metadata } from "next";
 
 import { AuthLevel, checkAuthenticationLevel } from "@lib/server/route-protection";
 import { buildUrlWithRequestId, SearchParams } from "@lib/utils";
@@ -10,17 +9,11 @@ import { buildUrlWithRequestId, SearchParams } from "@lib/utils";
  *--------------------------------------------*/
 import { getImageUrl } from "@lib/utils/imageUrl";
 import { I18n } from "@i18n";
-import { serverTranslation } from "@i18n/server";
 import { UserAvatar } from "@components/account/user-avatar/UserAvatar";
 import { AuthPanel } from "@components/auth/AuthPanel";
 import { CircleCheckIcon } from "@components/icons/CircleCheckIcon";
 import { LinkButton } from "@components/ui/button/LinkButton";
 import { Image } from "@components/ui/image/Image";
-
-export async function generateMetadata(): Promise<Metadata> {
-  const { t } = await serverTranslation("allSet");
-  return { title: t("title") };
-}
 
 export default async function Page(props: { searchParams: Promise<SearchParams> }) {
   const searchParams = await props.searchParams;

--- a/app/(auth)/before-you-start/page.tsx
+++ b/app/(auth)/before-you-start/page.tsx
@@ -1,13 +1,7 @@
 /*--------------------------------------------*
- * Framework and Third-Party
- *--------------------------------------------*/
-import { Metadata } from "next";
-
-/*--------------------------------------------*
  * Internal Aliases
  *--------------------------------------------*/
 import { SearchParams } from "@lib/utils";
-import { serverTranslation } from "@i18n/server";
 import { I18n } from "@i18n/Translate";
 import { AuthPanel } from "@components/auth/AuthPanel";
 
@@ -18,11 +12,6 @@ import { Step } from "./components/Step";
  * Parent Relative
  *--------------------------------------------*/
 import { Title } from "./components/Title";
-
-export async function generateMetadata(): Promise<Metadata> {
-  const { t } = await serverTranslation("beforeYouStart");
-  return { title: t("title") };
-}
 
 export default async function Page(props: { searchParams: Promise<SearchParams> }) {
   const searchParams = await props.searchParams;

--- a/app/(auth)/contact-us/page.tsx
+++ b/app/(auth)/contact-us/page.tsx
@@ -1,23 +1,13 @@
 /*--------------------------------------------*
- * Framework and Third-Party
- *--------------------------------------------*/
-import { Metadata } from "next";
-
-/*--------------------------------------------*
  * Internal Aliases
  *--------------------------------------------*/
-import { serverTranslation } from "@i18n/server";
+
 import { AuthPanel } from "@components/auth/AuthPanel";
 
 /*--------------------------------------------*
  * Local Relative
  *--------------------------------------------*/
 import { ContactUsForm } from "./components/ContactUsForm";
-
-export async function generateMetadata(): Promise<Metadata> {
-  const { t } = await serverTranslation("contact-us");
-  return { title: t("title") };
-}
 
 export default async function ContactUsPage() {
   return (

--- a/app/(auth)/mfa/page.tsx
+++ b/app/(auth)/mfa/page.tsx
@@ -1,7 +1,7 @@
 /*--------------------------------------------*
  * Framework and Third-Party
  *--------------------------------------------*/
-import { Metadata } from "next";
+
 import { redirect } from "next/navigation";
 import { AuthenticationMethodType } from "@zitadel/proto/zitadel/user/v2/user_service_pb";
 
@@ -11,7 +11,6 @@ import { AuthenticationMethodType } from "@zitadel/proto/zitadel/user/v2/user_se
 import { AuthLevel, checkAuthenticationLevel } from "@lib/server/route-protection";
 import { buildUrlWithRequestId } from "@lib/utils";
 import { SearchParams } from "@lib/utils";
-import { serverTranslation } from "@i18n/server";
 import { UserAvatar } from "@components/account/user-avatar/UserAvatar";
 import { AuthPanel } from "@components/auth/AuthPanel";
 
@@ -21,11 +20,6 @@ import { AuthPanel } from "@components/auth/AuthPanel";
 import { ChooseSecondFactor } from "./components/ChooseSecondFactor";
 // Strong MFA methods that must be configured before accessing the MFA selection page
 const STRONG_MFA_METHODS = [AuthenticationMethodType.TOTP, AuthenticationMethodType.U2F];
-
-export async function generateMetadata(): Promise<Metadata> {
-  const { t } = await serverTranslation("mfa");
-  return { title: t("verify.title") };
-}
 
 export default async function Page(props: { searchParams: Promise<SearchParams> }) {
   const searchParams = await props.searchParams;

--- a/app/(auth)/mfa/set/page.tsx
+++ b/app/(auth)/mfa/set/page.tsx
@@ -1,14 +1,8 @@
 /*--------------------------------------------*
- * Framework and Third-Party
- *--------------------------------------------*/
-import { Metadata } from "next";
-
-/*--------------------------------------------*
  * Internal Aliases
  *--------------------------------------------*/
 import { AuthLevel, checkAuthenticationLevel } from "@lib/server/route-protection";
 import { SearchParams } from "@lib/utils";
-import { serverTranslation } from "@i18n/server";
 import { AuthPanel } from "@components/auth/AuthPanel";
 
 /*--------------------------------------------*
@@ -16,25 +10,18 @@ import { AuthPanel } from "@components/auth/AuthPanel";
  *--------------------------------------------*/
 import { ChooseSecondFactorToSetup } from "../../u2f/set/components/ChooseSecondFactorToSetup";
 
-export async function generateMetadata(): Promise<Metadata> {
-  const { t } = await serverTranslation("mfa");
-  return { title: t("set.title") };
-}
-
 export default async function Page(props: { searchParams: Promise<SearchParams> }) {
   const searchParams = await props.searchParams;
   const { requestId } = searchParams;
   await checkAuthenticationLevel(AuthLevel.MFA_CHANGE_REQUIRED, requestId);
 
   return (
-    <>
-      <AuthPanel titleI18nKey="set.title" descriptionI18nKey="set.description" namespace="mfa">
-        <div className="w-full">
-          <div className="flex flex-col space-y-4">
-            <ChooseSecondFactorToSetup checkAfter={true} requestId={requestId} />
-          </div>
+    <AuthPanel titleI18nKey="set.title" descriptionI18nKey="set.description" namespace="mfa">
+      <div className="w-full">
+        <div className="flex flex-col space-y-4">
+          <ChooseSecondFactorToSetup checkAfter={true} requestId={requestId} />
         </div>
-      </AuthPanel>
-    </>
+      </div>
+    </AuthPanel>
   );
 }

--- a/app/(auth)/otp/time-based/page.tsx
+++ b/app/(auth)/otp/time-based/page.tsx
@@ -1,21 +1,10 @@
-/*--------------------------------------------*
- * Framework and Third-Party
- *--------------------------------------------*/
-import { Metadata } from "next";
-
 import { LoginTOTP } from "@root/app/(auth)/otp/time-based/components/LoginTOTP";
 import { AuthLevel, checkAuthenticationLevel } from "@lib/server/route-protection";
 import { SearchParams } from "@lib/utils";
 /*--------------------------------------------*
  * Internal Aliases
  *--------------------------------------------*/
-import { serverTranslation } from "@i18n/server";
 import { AuthPanel } from "@components/auth/AuthPanel";
-
-export async function generateMetadata(): Promise<Metadata> {
-  const { t } = await serverTranslation("otp");
-  return { title: t("verify.title") };
-}
 
 export default async function Page(props: { searchParams: Promise<SearchParams> }) {
   const searchParams = await props.searchParams;

--- a/app/(auth)/page.tsx
+++ b/app/(auth)/page.tsx
@@ -1,24 +1,18 @@
 /*--------------------------------------------*
  * Framework and Third-Party
  *--------------------------------------------*/
-import { Metadata } from "next";
 
 /*--------------------------------------------*
  * Internal Aliases
  *--------------------------------------------*/
 import { getAllSessions } from "@lib/cookies";
 import { buildUrlWithRequestId, SearchParams } from "@lib/utils";
-import { serverTranslation } from "@i18n/server";
 import { AuthPanel } from "@components/auth/AuthPanel";
 
 /*--------------------------------------------*
  * Local Relative
  *--------------------------------------------*/
 import { SignIn } from "./components/SignIn";
-export async function generateMetadata(): Promise<Metadata> {
-  const { t } = await serverTranslation("start");
-  return { title: t("title") };
-}
 
 export default async function LoginPage(props: { searchParams: Promise<SearchParams> }) {
   const searchParams = await props.searchParams;

--- a/app/(auth)/password/change/page.tsx
+++ b/app/(auth)/password/change/page.tsx
@@ -1,7 +1,7 @@
 /*--------------------------------------------*
  * Framework and Third-Party
  *--------------------------------------------*/
-import { Metadata } from "next";
+
 import { redirect } from "next/navigation";
 
 /*--------------------------------------------*
@@ -12,17 +12,12 @@ import { AuthLevel, checkAuthenticationLevel, hasStrongMFA } from "@lib/server/r
 import { buildUrlWithRequestId } from "@lib/utils";
 import { SearchParams } from "@lib/utils";
 import { getPasswordComplexitySettings } from "@lib/zitadel";
-import { serverTranslation } from "@i18n/server";
 import { AuthPanel } from "@components/auth/AuthPanel";
 
 /*--------------------------------------------*
  * Local Relative
  *--------------------------------------------*/
 import { ChangePasswordForm } from "./components/ChangePasswordForm";
-export async function generateMetadata(): Promise<Metadata> {
-  const { t } = await serverTranslation("password");
-  return { title: t("change.title") };
-}
 
 export default async function Page(props: { searchParams: Promise<SearchParams> }) {
   const { requestId } = await props.searchParams;

--- a/app/(auth)/password/change/verify/page.tsx
+++ b/app/(auth)/password/change/verify/page.tsx
@@ -1,7 +1,7 @@
 /*--------------------------------------------*
  * Framework and Third-Party
  *--------------------------------------------*/
-import { Metadata } from "next";
+
 import { redirect } from "next/navigation";
 import { AuthenticationMethodType } from "@zitadel/proto/zitadel/user/v2/user_service_pb";
 
@@ -11,14 +11,8 @@ import { AuthenticationMethodType } from "@zitadel/proto/zitadel/user/v2/user_se
 import { logMessage } from "@lib/logger";
 import { AuthLevel, checkAuthenticationLevel } from "@lib/server/route-protection";
 import type { SearchParams } from "@lib/utils";
-import { serverTranslation } from "@i18n/server";
 import { AuthPanel } from "@components/auth/AuthPanel";
 import { StrongFactorSelection } from "@components/mfa/StrongFactorSelection";
-
-export async function generateMetadata(): Promise<Metadata> {
-  const { t } = await serverTranslation("mfa");
-  return { title: t("verify.title") };
-}
 
 export default async function Page(props: { searchParams: Promise<SearchParams> }) {
   const { requestId } = await props.searchParams;

--- a/app/(auth)/password/change/verify/time-based/page.tsx
+++ b/app/(auth)/password/change/verify/time-based/page.tsx
@@ -1,7 +1,6 @@
 /*--------------------------------------------*
  * Framework and Third-Party
  *--------------------------------------------*/
-import { Metadata } from "next";
 import { redirect } from "next/navigation";
 import { AuthenticationMethodType } from "@zitadel/proto/zitadel/user/v2/user_service_pb";
 
@@ -11,13 +10,7 @@ import { LoginTOTP } from "@root/app/(auth)/otp/time-based/components/LoginTOTP"
  *--------------------------------------------*/
 import { AuthLevel, checkAuthenticationLevel } from "@lib/server/route-protection";
 import { buildUrlWithRequestId, type SearchParams } from "@lib/utils";
-import { serverTranslation } from "@i18n/server";
 import { AuthPanel } from "@components/auth/AuthPanel";
-
-export async function generateMetadata(): Promise<Metadata> {
-  const { t } = await serverTranslation("otp");
-  return { title: t("verify.authAppTitle") };
-}
 
 export default async function Page(props: { searchParams: Promise<SearchParams> }) {
   const { requestId } = await props.searchParams;

--- a/app/(auth)/password/change/verify/u2f/page.tsx
+++ b/app/(auth)/password/change/verify/u2f/page.tsx
@@ -1,7 +1,7 @@
 /*--------------------------------------------*
  * Framework and Third-Party
  *--------------------------------------------*/
-import { Metadata } from "next";
+
 import { redirect } from "next/navigation";
 import { AuthenticationMethodType } from "@zitadel/proto/zitadel/user/v2/user_service_pb";
 
@@ -11,14 +11,9 @@ import { AuthenticationMethodType } from "@zitadel/proto/zitadel/user/v2/user_se
 import { AuthLevel, checkAuthenticationLevel } from "@lib/server/route-protection";
 import type { SearchParams } from "@lib/utils";
 import { buildUrlWithRequestId } from "@lib/utils";
-import { serverTranslation } from "@i18n/server";
 import { UserAvatar } from "@components/account/user-avatar";
 import { AuthPanel } from "@components/auth/AuthPanel";
 import { LoginU2F } from "@components/mfa/LoginU2F";
-export async function generateMetadata(): Promise<Metadata> {
-  const { t } = await serverTranslation("u2f");
-  return { title: t("verify.title") };
-}
 
 export default async function Page(props: { searchParams: Promise<SearchParams> }) {
   const { requestId } = await props.searchParams;

--- a/app/(auth)/password/reset/page.tsx
+++ b/app/(auth)/password/reset/page.tsx
@@ -1,23 +1,13 @@
 /*--------------------------------------------*
- * Framework and Third-Party
- *--------------------------------------------*/
-import { Metadata } from "next";
-
-/*--------------------------------------------*
  * Local Relative
  *--------------------------------------------*/
 import { SearchParams } from "@lib/utils";
 /*--------------------------------------------*
  * Internal Aliases
  *--------------------------------------------*/
-import { serverTranslation } from "@i18n/server";
 import { AuthPanel } from "@components/auth/AuthPanel";
 
 import { UserNameForm } from "./components/UserNameForm";
-export async function generateMetadata(): Promise<Metadata> {
-  const { t } = await serverTranslation("password");
-  return { title: t("reset.title") };
-}
 
 export default async function Page(props: { searchParams: Promise<SearchParams> }) {
   const { requestId } = await props.searchParams;

--- a/app/(auth)/password/reset/set/page.tsx
+++ b/app/(auth)/password/reset/set/page.tsx
@@ -1,7 +1,7 @@
 /*--------------------------------------------*
  * Framework and Third-Party
  *--------------------------------------------*/
-import { Metadata } from "next";
+
 import { redirect } from "next/navigation";
 
 import { logMessage } from "@lib/logger";
@@ -11,18 +11,12 @@ import { logMessage } from "@lib/logger";
 import { AuthLevel, checkAuthenticationLevel } from "@lib/server/route-protection";
 import { buildUrlWithRequestId, type SearchParams } from "@lib/utils";
 import { getPasswordComplexitySettings } from "@lib/zitadel";
-import { serverTranslation } from "@i18n/server";
 import { AuthPanel } from "@components/auth/AuthPanel";
 
 /*--------------------------------------------*
  * Parent Relative
  *--------------------------------------------*/
 import { PasswordReset } from "../components/PasswordReset";
-
-export async function generateMetadata(): Promise<Metadata> {
-  const { t } = await serverTranslation("password");
-  return { title: t("reset.title") };
-}
 
 export default async function Page(props: { searchParams: Promise<SearchParams> }) {
   const { requestId } = await props.searchParams;

--- a/app/(auth)/password/reset/verify/page.tsx
+++ b/app/(auth)/password/reset/verify/page.tsx
@@ -1,7 +1,7 @@
 /*--------------------------------------------*
  * Framework and Third-Party
  *--------------------------------------------*/
-import { Metadata } from "next";
+
 import { redirect } from "next/navigation";
 import { AuthenticationMethodType } from "@zitadel/proto/zitadel/user/v2/user_service_pb";
 
@@ -11,14 +11,8 @@ import { AuthenticationMethodType } from "@zitadel/proto/zitadel/user/v2/user_se
 import { logMessage } from "@lib/logger";
 import { AuthLevel, checkAuthenticationLevel } from "@lib/server/route-protection";
 import { buildUrlWithRequestId, type SearchParams } from "@lib/utils";
-import { serverTranslation } from "@i18n/server";
 import { AuthPanel } from "@components/auth/AuthPanel";
 import { StrongFactorSelection } from "@components/mfa/StrongFactorSelection";
-
-export async function generateMetadata(): Promise<Metadata> {
-  const { t } = await serverTranslation("mfa");
-  return { title: t("verify.title") };
-}
 
 export default async function Page(props: { searchParams: Promise<SearchParams> }) {
   const { requestId } = await props.searchParams;

--- a/app/(auth)/password/reset/verify/time-based/page.tsx
+++ b/app/(auth)/password/reset/verify/time-based/page.tsx
@@ -1,7 +1,7 @@
 /*--------------------------------------------*
  * Framework and Third-Party
  *--------------------------------------------*/
-import { Metadata } from "next";
+
 import { redirect } from "next/navigation";
 import { AuthenticationMethodType } from "@zitadel/proto/zitadel/user/v2/user_service_pb";
 
@@ -12,13 +12,7 @@ import { AuthLevel, checkAuthenticationLevel } from "@lib/server/route-protectio
  *--------------------------------------------*/
 import type { SearchParams } from "@lib/utils";
 import { buildUrlWithRequestId } from "@lib/utils";
-import { serverTranslation } from "@i18n/server";
 import { AuthPanel } from "@components/auth/AuthPanel";
-
-export async function generateMetadata(): Promise<Metadata> {
-  const { t } = await serverTranslation("otp");
-  return { title: t("verify.authAppTitle") };
-}
 
 export default async function Page(props: { searchParams: Promise<SearchParams> }) {
   const { requestId } = await props.searchParams;

--- a/app/(auth)/password/reset/verify/u2f/page.tsx
+++ b/app/(auth)/password/reset/verify/u2f/page.tsx
@@ -1,7 +1,7 @@
 /*--------------------------------------------*
  * Framework and Third-Party
  *--------------------------------------------*/
-import { Metadata } from "next";
+
 import { redirect } from "next/navigation";
 import { AuthenticationMethodType } from "@zitadel/proto/zitadel/user/v2/user_service_pb";
 
@@ -10,15 +10,9 @@ import { AuthenticationMethodType } from "@zitadel/proto/zitadel/user/v2/user_se
  *--------------------------------------------*/
 import { AuthLevel, checkAuthenticationLevel } from "@lib/server/route-protection";
 import type { SearchParams } from "@lib/utils";
-import { serverTranslation } from "@i18n/server";
 import { UserAvatar } from "@components/account/user-avatar";
 import { AuthPanel } from "@components/auth/AuthPanel";
 import { LoginU2F } from "@components/mfa/LoginU2F";
-
-export async function generateMetadata(): Promise<Metadata> {
-  const { t } = await serverTranslation("u2f");
-  return { title: t("verify.title") };
-}
 
 export default async function Page(props: { searchParams: Promise<SearchParams> }) {
   const { requestId } = await props.searchParams;

--- a/app/(auth)/register/page.tsx
+++ b/app/(auth)/register/page.tsx
@@ -1,24 +1,17 @@
 /*--------------------------------------------*
  * Framework and Third-Party
  *--------------------------------------------*/
-import { Metadata } from "next";
 
 /*--------------------------------------------*
  * Internal Aliases
  *--------------------------------------------*/
 import { SearchParams } from "@lib/utils";
-import { serverTranslation } from "@i18n/server";
 import { AuthPanel } from "@components/auth/AuthPanel";
 
 /*--------------------------------------------*
  * Local Relative
  *--------------------------------------------*/
 import { RegisterForm } from "./components/RegisterForm";
-
-export async function generateMetadata(): Promise<Metadata> {
-  const { t } = await serverTranslation("register");
-  return { title: t("title") };
-}
 
 export default async function Page(props: { searchParams: Promise<SearchParams> }) {
   const searchParams = await props.searchParams;

--- a/app/(auth)/register/password/page.tsx
+++ b/app/(auth)/register/password/page.tsx
@@ -1,7 +1,7 @@
 /*--------------------------------------------*
  * Framework and Third-Party
  *--------------------------------------------*/
-import { Metadata } from "next";
+
 import { redirect } from "next/navigation";
 
 /*--------------------------------------------*
@@ -9,17 +9,12 @@ import { redirect } from "next/navigation";
  *--------------------------------------------*/
 import { logMessage } from "@lib/logger";
 import { getPasswordComplexitySettings } from "@lib/zitadel";
-import { serverTranslation } from "@i18n/server";
 import { AuthPanel } from "@components/auth/AuthPanel";
 
 /*--------------------------------------------*
  * Local Relative
  *--------------------------------------------*/
 import { PasswordPageClient } from "./PasswordPageClient";
-export async function generateMetadata(): Promise<Metadata> {
-  const { t } = await serverTranslation("password");
-  return { title: t("create.title") };
-}
 
 export default async function Page() {
   const passwordComplexitySettings = await getPasswordComplexitySettings().catch((_error) => {
@@ -33,7 +28,7 @@ export default async function Page() {
 
   return (
     <AuthPanel
-      titleI18nKey="password.title"
+      titleI18nKey="create.title"
       descriptionI18nKey="password.description"
       namespace="register"
     >

--- a/app/(auth)/u2f/page.tsx
+++ b/app/(auth)/u2f/page.tsx
@@ -1,7 +1,7 @@
 /*--------------------------------------------*
  * Framework and Third-Party
  *--------------------------------------------*/
-import { Metadata } from "next";
+
 import { redirect } from "next/navigation";
 
 /*--------------------------------------------*
@@ -11,15 +11,9 @@ import { logMessage } from "@lib/logger";
 import { AuthLevel, checkAuthenticationLevel } from "@lib/server/route-protection";
 import { buildUrlWithRequestId, SearchParams } from "@lib/utils";
 import { getSafeRedirectUrl } from "@lib/utils/redirect-validator";
-import { serverTranslation } from "@i18n/server";
 import { UserAvatar } from "@components/account/user-avatar";
 import { AuthPanel } from "@components/auth/AuthPanel";
 import { LoginU2F } from "@components/mfa/LoginU2F";
-
-export async function generateMetadata(): Promise<Metadata> {
-  const { t } = await serverTranslation("u2f");
-  return { title: t("verify.title") };
-}
 
 export default async function Page(props: { searchParams: Promise<SearchParams> }) {
   const searchParams = await props.searchParams;

--- a/app/(auth)/u2f/set/page.tsx
+++ b/app/(auth)/u2f/set/page.tsx
@@ -1,7 +1,7 @@
 /*--------------------------------------------*
  * Framework and Third-Party
  *--------------------------------------------*/
-import { Metadata } from "next";
+
 import { redirect } from "next/navigation";
 
 /*--------------------------------------------*
@@ -10,16 +10,10 @@ import { redirect } from "next/navigation";
 import { logMessage } from "@lib/logger";
 import { AuthLevel, checkAuthenticationLevel } from "@lib/server/route-protection";
 import { buildUrlWithRequestId } from "@lib/utils";
-import { serverTranslation } from "@i18n/server";
 import { UserAvatar } from "@components/account/user-avatar";
 import { AuthPanel } from "@components/auth/AuthPanel";
 
 import { RegisterU2f } from "./components/RegisterU2f";
-
-export async function generateMetadata(): Promise<Metadata> {
-  const { t } = await serverTranslation("u2f");
-  return { title: t("set.title") };
-}
 
 export default async function Page(props: {
   searchParams: Promise<Record<string | number | symbol, string | undefined>>;

--- a/app/(auth)/verify/page.tsx
+++ b/app/(auth)/verify/page.tsx
@@ -1,14 +1,12 @@
 /*--------------------------------------------*
  * Framework and Third-Party
  *--------------------------------------------*/
-import { Metadata } from "next";
 
 /*--------------------------------------------*
  * Internal Aliases
  *--------------------------------------------*/
 import { AuthLevel, checkAuthenticationLevel } from "@lib/server/route-protection";
 import { SearchParams } from "@lib/utils";
-import { serverTranslation } from "@i18n/server";
 import { UserAvatar } from "@components/account/user-avatar";
 import { AuthPanel } from "@components/auth/AuthPanel";
 
@@ -17,11 +15,6 @@ import { AuthPanel } from "@components/auth/AuthPanel";
  *--------------------------------------------*/
 import { VerifyEmailForm } from "./components/VerifyEmailForm";
 import { sendVerificationEmail } from "./action";
-
-export async function generateMetadata(): Promise<Metadata> {
-  const { t } = await serverTranslation("otp");
-  return { title: t("verify.title") };
-}
 
 export default async function Page(props: { searchParams: Promise<SearchParams> }) {
   const searchParams = await props.searchParams;

--- a/app/account/layout.tsx
+++ b/app/account/layout.tsx
@@ -2,32 +2,16 @@
  * Framework and Third-Party
  *--------------------------------------------*/
 import { Suspense } from "react";
-import { Metadata } from "next";
 
 /*--------------------------------------------*
  * Internal Aliases
  *--------------------------------------------*/
-import { serverTranslation } from "@i18n/server";
 import { VersionUpdater } from "@components/auth/VersionUpdater";
 import { YourAccount } from "@components/auth/YourAccount";
 import { Footer, FooterSkeleton } from "@components/layout/footer/Footer";
 import { FooterLinks } from "@components/layout/footer/FooterLinks";
 import { SiteHeader, SiteHeaderSkeleton } from "@components/layout/site-header/SiteHeader";
 import LanguageToggle from "@components/ui/language-toggle/LanguageToggle";
-
-export async function generateMetadata(): Promise<Metadata> {
-  const { t } = await serverTranslation("account");
-  return {
-    title: {
-      default: t("title"),
-      // wraps any sub-page's title, so %s gets replaced with the page-specific string
-      // Note: each sub page must update it's title e.g. ...generateMetadata()... return {title: "My Page Title"}..
-      // TODO: this may need to be moved to a higher level when new sections are added
-      template: `%s | ${t("title")}`,
-    },
-  };
-}
-
 /*--------------------------------------------*
  * Local Relative
  *--------------------------------------------*/

--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -1,7 +1,7 @@
 /*--------------------------------------------*
  * Framework and Third-Party
  *--------------------------------------------*/
-import { Metadata } from "next";
+
 import { redirect } from "next/navigation";
 
 /*--------------------------------------------*
@@ -11,7 +11,7 @@ import { logMessage } from "@lib/logger";
 import { AuthLevel, checkAuthenticationLevel } from "@lib/server/route-protection";
 import { buildUrlWithRequestId, SearchParams } from "@lib/utils";
 import { getU2FList, getUserByID } from "@lib/zitadel";
-import { serverTranslation } from "@i18n/server";
+import { PageTitle } from "@components/ui/title/PageTitle";
 
 /*--------------------------------------------*
  * Local Relative
@@ -20,11 +20,6 @@ import { MFAAuthentication } from "./components/MFAAuthentication";
 import { PasswordAuthentication } from "./components/PasswordAuthentication";
 import { PersonalDetails } from "./components/PersonalDetails";
 import { VerifiedAccount } from "./components/VerifiedAccount";
-
-export async function generateMetadata(): Promise<Metadata> {
-  const { t } = await serverTranslation("account");
-  return { title: t("navigation.title") };
-}
 
 export default async function Page(props: { searchParams: Promise<SearchParams> }) {
   const searchParams = await props.searchParams;
@@ -52,6 +47,7 @@ export default async function Page(props: { searchParams: Promise<SearchParams> 
 
   return (
     <>
+      <PageTitle key="navigation.title" namespace="account" />
       <PersonalDetails firstName={firstName} lastName={lastName} className="mb-4" />
       <VerifiedAccount email={email} className="mb-4" />
       <PasswordAuthentication className="mb-4" />

--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -47,7 +47,7 @@ export default async function Page(props: { searchParams: Promise<SearchParams> 
 
   return (
     <>
-      <PageTitle key="navigation.title" namespace="account" />
+      <PageTitle i18nKey="navigation.title" namespace="account" />
       <PersonalDetails firstName={firstName} lastName={lastName} className="mb-4" />
       <VerifiedAccount email={email} className="mb-4" />
       <PasswordAuthentication className="mb-4" />

--- a/components/auth/AuthPanel.tsx
+++ b/components/auth/AuthPanel.tsx
@@ -9,6 +9,7 @@ import { ReactNode } from "react";
 import { getImageUrl } from "@lib/utils/imageUrl";
 import { I18n } from "@i18n";
 import { Image } from "@components/ui/image/Image";
+import { PageTitle } from "@components/ui/title/PageTitle";
 
 /*--------------------------------------------*
  * Local Relative
@@ -44,6 +45,7 @@ export const AuthPanel = ({
 
   return (
     <div id={panelId}>
+      <PageTitle i18nKey={titleI18nKey} namespace={namespace} />
       {imageSrc && (
         <div className="mb-6 flex justify-center">
           <Image src={getImageUrl(imageSrc)} alt="" width={125} height={96} />

--- a/components/ui/title/PageTitle.tsx
+++ b/components/ui/title/PageTitle.tsx
@@ -1,0 +1,8 @@
+"use client";
+
+import { useTranslation } from "@i18n";
+export const PageTitle = ({ i18nKey, namespace }: { i18nKey: string; namespace: string }) => {
+  const { t } = useTranslation(namespace);
+
+  return <title>{t(i18nKey)}</title>;
+};


### PR DESCRIPTION
# Summary | Résumé
Fix Page title not changing when toggling language.

`generateMetadata` is only done once server side and does not update when client side language is toggled.  Leveraging a client component instead that uses `<title />` that is auto hoisted into the `<head>` section.

| Before | After | 
| --- | --- | 
| <img  alt="i18n title issue" src="https://github.com/user-attachments/assets/adf1bbcd-c592-4aa3-a322-fd58f6be6b7a" /> | <img  alt="i18n title fixed" src="https://github.com/user-attachments/assets/fce0936b-0d47-41d4-a7ca-3d53e559a3b8" /> | 


