### PR TITLE
chore: remove integration test service key

### DIFF
--- a/.github/workflows/docker-update-staging.yml
+++ b/.github/workflows/docker-update-staging.yml
@@ -66,7 +66,6 @@ jobs:
       password: ${{ secrets.STAGING_INTEGRATION_TEST_PASSWORD }}
       totp_secret: ${{ secrets.STAGING_INTEGRATION_TEST_TOTP_SECRET }}
       waf_geo_restriction_bypass: ${{ secrets.STAGING_WAF_GEO_RESTRICTION_BYPASS }}
-      zitadel_service_account_key: ${{ secrets.STAGING_INTEGRATION_TEST_ZITADEL_SERVICE_ACCOUNT_KEY }}
       
   workflow-failure:
     needs: 

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -28,8 +28,6 @@ on:
         required: true
       waf_geo_restriction_bypass:
         required: true
-      zitadel_service_account_key:
-        required: true
 
 env:
   AWS_REGION: ca-central-1
@@ -76,7 +74,6 @@ jobs:
           PASSWORD: ${{ secrets.password }}
           TOTP_SECRET: ${{ secrets.totp_secret }}
           WAF_GEO_RESTRICTION_BYPASS: ${{ secrets.waf_geo_restriction_bypass }}
-          ZITADEL_SERVICE_ACCOUNT_KEY: ${{ secrets.zitadel_service_account_key }}
         run: pnpm test:playwright test/playwright/login.totp.spec.ts
 
       - name: Configure AWS credentials using OIDC

--- a/.github/workflows/pr-review-deploy.yml
+++ b/.github/workflows/pr-review-deploy.yml
@@ -160,4 +160,3 @@ jobs:
       password: ${{ secrets.STAGING_INTEGRATION_TEST_PASSWORD }}
       totp_secret: ${{ secrets.STAGING_INTEGRATION_TEST_TOTP_SECRET }}
       waf_geo_restriction_bypass: ${{ secrets.STAGING_WAF_GEO_RESTRICTION_BYPASS }}
-      zitadel_service_account_key: ${{ secrets.STAGING_INTEGRATION_TEST_ZITADEL_SERVICE_ACCOUNT_KEY }}


### PR DESCRIPTION
# Summary
The integration tests no longer call the Zitadel API from GitHub so we can removed the service user's key.
