### PR TITLE
fix: fail-closed when session is invalid

### DIFF
--- a/lib/oidc.test.ts
+++ b/lib/oidc.test.ts
@@ -1,3 +1,5 @@
+import { create } from "@zitadel/client";
+import { CreateCallbackResponseSchema } from "@zitadel/proto/zitadel/oidc/v2/oidc_service_pb";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { sendLoginname } from "@lib/server/loginname";
@@ -31,6 +33,44 @@ vi.mock("./session", () => ({
 describe("loginWithOIDCAndSession", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  it("creates a callback for a valid session", async () => {
+    vi.mocked(isSessionValid).mockResolvedValue(true);
+    vi.mocked(createCallback).mockResolvedValue(
+      create(CreateCallbackResponseSchema, { callbackUrl: "/account" })
+    );
+
+    const result = await loginWithOIDCAndSession({
+      authRequest: "oidc_auth-request-123",
+      sessionId: "session-123",
+      sessions: [
+        {
+          id: "session-123",
+        } as never,
+      ],
+      sessionCookies: [
+        {
+          id: "session-123",
+          token: "session-token",
+        } as never,
+      ],
+    });
+
+    expect(result).toEqual({ redirect: "/account" });
+    expect(createCallback).toHaveBeenCalledWith({
+      req: expect.objectContaining({
+        authRequestId: "auth-request-123",
+        callbackKind: expect.objectContaining({
+          case: "session",
+          value: expect.objectContaining({
+            sessionId: "session-123",
+            sessionToken: "session-token",
+          }),
+        }),
+      }),
+    });
+    expect(sendLoginname).not.toHaveBeenCalled();
   });
 
   it("does not create a callback for an incomplete registration session", async () => {

--- a/lib/oidc.test.ts
+++ b/lib/oidc.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { sendLoginname } from "@lib/server/loginname";
+import { createCallback } from "@lib/zitadel";
+
+import { loginWithOIDCAndSession } from "./oidc";
+import { isSessionValid } from "./session";
+
+vi.mock("@lib/logger", () => ({
+  logMessage: {
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+vi.mock("@lib/server/loginname", () => ({
+  sendLoginname: vi.fn(),
+}));
+
+vi.mock("@lib/zitadel", () => ({
+  createCallback: vi.fn(),
+  getAuthRequest: vi.fn(),
+  getLoginSettings: vi.fn(),
+}));
+
+vi.mock("./session", () => ({
+  isSessionValid: vi.fn(),
+}));
+
+describe("loginWithOIDCAndSession", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not create a callback for an incomplete registration session", async () => {
+    vi.mocked(isSessionValid).mockResolvedValue(false);
+    vi.mocked(sendLoginname).mockResolvedValue({ error: "Registration is incomplete" });
+
+    const result = await loginWithOIDCAndSession({
+      authRequest: "oidc_auth-request-123",
+      sessionId: "session-123",
+      sessions: [
+        {
+          id: "session-123",
+          factors: {
+            user: {
+              id: "user-123",
+              loginName: "user@example.com",
+            },
+          },
+        } as never,
+      ],
+      sessionCookies: [
+        {
+          id: "session-123",
+          token: "session-token",
+        } as never,
+      ],
+    });
+
+    expect(result).toEqual({ error: "Registration is incomplete" });
+    expect(sendLoginname).toHaveBeenCalledWith({
+      loginName: "user@example.com",
+      requestId: "oidc_auth-request-123",
+    });
+    expect(createCallback).not.toHaveBeenCalled();
+  });
+});

--- a/lib/oidc.ts
+++ b/lib/oidc.ts
@@ -44,23 +44,33 @@ export async function loginWithOIDCAndSession({
 
     logMessage.debug(`OIDC session validity for requestId ${oidcRequestId}: ${isValid}`);
 
-    if (!isValid && selectedSession.factors?.user) {
+    if (!isValid) {
       logMessage.info(
         `OIDC session expired for requestId: ${oidcRequestId}, redirecting for re-authentication`
       );
       // if the session is not valid anymore, we need to redirect the user to re-authenticate /
       // TODO: handle IDP intent direcly if available
-      const command: SendLoginnameCommand = {
-        loginName: selectedSession.factors.user?.loginName,
-        requestId: oidcRequestId,
-      };
+      const loginName = selectedSession.factors?.user?.loginName;
 
-      const res = await sendLoginname(command);
+      if (loginName) {
+        const command: SendLoginnameCommand = {
+          loginName,
+          requestId: oidcRequestId,
+        };
 
-      if (res && "redirect" in res && res?.redirect) {
-        logMessage.debug(`Re-authentication redirect initiated for requestId: ${oidcRequestId}`);
-        return { redirect: res.redirect };
+        const res = await sendLoginname(command);
+
+        if (res && "redirect" in res && res?.redirect) {
+          logMessage.debug(`Re-authentication redirect initiated for requestId: ${oidcRequestId}`);
+          return { redirect: res.redirect };
+        }
+
+        if (res && "error" in res && res.error) {
+          return { error: res.error };
+        }
       }
+
+      return { error: "Session not found or invalid" };
     }
 
     const cookie = sessionCookies.find((cookie) => cookie.id === selectedSession?.id);

--- a/lib/oidc.ts
+++ b/lib/oidc.ts
@@ -58,15 +58,18 @@ export async function loginWithOIDCAndSession({
           requestId: oidcRequestId,
         };
 
-        const res = await sendLoginname(command);
+        const response = await sendLoginname(command);
 
-        if (res && "redirect" in res && res?.redirect) {
-          logMessage.debug(`Re-authentication redirect initiated for requestId: ${oidcRequestId}`);
-          return { redirect: res.redirect };
-        }
-
-        if (res && "error" in res && res.error) {
-          return { error: res.error };
+        if (response) {
+          if ("redirect" in response && response.redirect) {
+            logMessage.debug(
+              `Re-authentication redirect initiated for requestId: ${oidcRequestId}`
+            );
+            return { redirect: response.redirect };
+          }
+          if ("error" in response && response.error) {
+            return { error: response.error };
+          }
         }
       }
 


### PR DESCRIPTION
# Summary 
There is currently a gap where if the portal determines a session is invalid and SendLoginnameCommand does not return a `redirect`, the portal will still attempt to complete the OIDC authentication flow by falling through to createCallback.

This blocks this fall through and fails the OIDC authentication flow if the session is determined to be invalid and the user cannot be re-authenticated.

ℹ️ It is likely that Zitadel would also fail the OIDC auth flow at the callback stage, but this prevents the extra call and possibility of an OIDC auth succeeding with an invalid session.

# Related
- https://github.com/cds-snc/platform-core-services/issues/1065