### PR TITLE
fix: add instrumentation to debug unhealthy tasks

### DIFF
--- a/instrumentation.node.ts
+++ b/instrumentation.node.ts
@@ -1,0 +1,111 @@
+import { monitorEventLoopDelay, performance, PerformanceObserver } from "node:perf_hooks";
+
+import { logMessage } from "@lib/logger";
+
+const METRICS_INTERVAL_MS = 30_000;
+const NANOSECONDS_PER_MILLISECOND = 1_000_000;
+const BYTES_PER_MEGABYTE = 1024 * 1024;
+const PRESSURE_WARNING_INTERVALS = 2;
+const EVENT_LOOP_DELAY_P99_WARNING_MS = 200;
+const EVENT_LOOP_DELAY_MAX_WARNING_MS = 1_000;
+const EVENT_LOOP_UTILIZATION_WARNING = 0.9;
+const MEMORY_USAGE_WARNING = 0.85;
+
+export function registerRuntimeMetrics() {
+  const eventLoopDelay = monitorEventLoopDelay({ resolution: 20 });
+  let previousCpuUsage = process.cpuUsage();
+  let previousEventLoopUtilization = performance.eventLoopUtilization();
+  let previousSampleTime = performance.now();
+  let garbageCollectionCount = 0;
+  let garbageCollectionDurationMs = 0;
+  let consecutivePressureIntervals = 0;
+
+  const garbageCollectionObserver = new PerformanceObserver((entries) => {
+    for (const entry of entries.getEntries()) {
+      garbageCollectionCount += 1;
+      garbageCollectionDurationMs += entry.duration;
+    }
+  });
+
+  garbageCollectionObserver.observe({ type: "gc" });
+  eventLoopDelay.enable();
+
+  const timer = setInterval(() => {
+    try {
+      const sampleTime = performance.now();
+      const elapsedMs = sampleTime - previousSampleTime;
+      const cpuUsage = process.cpuUsage(previousCpuUsage);
+      const currentEventLoopUtilization = performance.eventLoopUtilization();
+      const eventLoopUtilization = performance.eventLoopUtilization(
+        currentEventLoopUtilization,
+        previousEventLoopUtilization
+      );
+      const memoryUsage = process.memoryUsage();
+      const constrainedMemoryBytes = process.constrainedMemory();
+      const memoryUsageRatio =
+        constrainedMemoryBytes > 0 ? memoryUsage.rss / constrainedMemoryBytes : null;
+      const eventLoopDelayP99Ms =
+        eventLoopDelay.count > 0 ? eventLoopDelay.percentile(99) / NANOSECONDS_PER_MILLISECOND : 0;
+      const eventLoopDelayMaxMs =
+        eventLoopDelay.count > 0 ? eventLoopDelay.max / NANOSECONDS_PER_MILLISECOND : 0;
+
+      const pressure = [
+        eventLoopDelayP99Ms >= EVENT_LOOP_DELAY_P99_WARNING_MS ? "event_loop_delay_p99" : null,
+        eventLoopDelayMaxMs >= EVENT_LOOP_DELAY_MAX_WARNING_MS ? "event_loop_delay_max" : null,
+        eventLoopUtilization.utilization >= EVENT_LOOP_UTILIZATION_WARNING
+          ? "event_loop_utilization"
+          : null,
+        memoryUsageRatio !== null && memoryUsageRatio >= MEMORY_USAGE_WARNING
+          ? "memory_usage"
+          : null,
+      ].filter((reason): reason is string => reason !== null);
+
+      consecutivePressureIntervals = pressure.length > 0 ? consecutivePressureIntervals + 1 : 0;
+
+      const metrics = {
+        event: "runtime_metrics",
+        uptimeSeconds: Math.round(process.uptime()),
+        CpuPercentOfOneCore: Number(
+          (((cpuUsage.user + cpuUsage.system) / (elapsedMs * 1_000)) * 100).toFixed(2)
+        ),
+        EventLoopUtilization: Number((eventLoopUtilization.utilization * 100).toFixed(2)),
+        EventLoopDelayP50: Number(
+          (eventLoopDelay.percentile(50) / NANOSECONDS_PER_MILLISECOND).toFixed(2)
+        ),
+        EventLoopDelayP95: Number(
+          (eventLoopDelay.percentile(95) / NANOSECONDS_PER_MILLISECOND).toFixed(2)
+        ),
+        EventLoopDelayP99: Number(eventLoopDelayP99Ms.toFixed(2)),
+        EventLoopDelayMax: Number(eventLoopDelayMaxMs.toFixed(2)),
+        RssMemoryMB: Number((memoryUsage.rss / BYTES_PER_MEGABYTE).toFixed(2)),
+        HeapUsedMB: Number((memoryUsage.heapUsed / BYTES_PER_MEGABYTE).toFixed(2)),
+        AvailableMemoryMB: Number((process.availableMemory() / BYTES_PER_MEGABYTE).toFixed(2)),
+        GarbageCollectionCount: garbageCollectionCount,
+        GarbageCollectionDuration: Number(garbageCollectionDurationMs.toFixed(2)),
+        heapTotalMB: Number((memoryUsage.heapTotal / BYTES_PER_MEGABYTE).toFixed(2)),
+        externalMB: Number((memoryUsage.external / BYTES_PER_MEGABYTE).toFixed(2)),
+        arrayBuffersMB: Number((memoryUsage.arrayBuffers / BYTES_PER_MEGABYTE).toFixed(2)),
+        constrainedMemoryMB: Number((constrainedMemoryBytes / BYTES_PER_MEGABYTE).toFixed(2)),
+        memoryUsageRatio: memoryUsageRatio === null ? null : Number(memoryUsageRatio.toFixed(4)),
+        pressure,
+      };
+
+      if (consecutivePressureIntervals >= PRESSURE_WARNING_INTERVALS) {
+        logMessage.warn("Runtime pressure detected", metrics);
+      } else {
+        logMessage.info("Runtime metrics", metrics);
+      }
+
+      previousCpuUsage = process.cpuUsage();
+      previousEventLoopUtilization = currentEventLoopUtilization;
+      previousSampleTime = sampleTime;
+      garbageCollectionCount = 0;
+      garbageCollectionDurationMs = 0;
+      eventLoopDelay.reset();
+    } catch (error) {
+      logMessage.error("Failed to collect runtime metrics", error);
+    }
+  }, METRICS_INTERVAL_MS);
+
+  timer.unref();
+}

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,5 +1,5 @@
 export async function register() {
-  if (process.env.NEXT_RUNTIME === "nodejs") {
+  if (process.env.RUNTIME_METRICS === "1") {
     const { registerRuntimeMetrics } = await import("./instrumentation.node");
     registerRuntimeMetrics();
   }

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,0 +1,6 @@
+export async function register() {
+  if (process.env.NEXT_RUNTIME === "nodejs") {
+    const { registerRuntimeMetrics } = await import("./instrumentation.node");
+    registerRuntimeMetrics();
+  }
+}

--- a/lib/logger.test.ts
+++ b/lib/logger.test.ts
@@ -42,12 +42,24 @@ describe("logMessage.info", () => {
     logMessage.info("info message");
     expect(mockPinoInstance.info).toHaveBeenCalledWith("info message");
   });
+
+  it("logs structured context with a message", () => {
+    const context = { event: "runtime_metrics", cpuPercent: 12.5 };
+    logMessage.info("Runtime metrics", context);
+    expect(mockPinoInstance.info).toHaveBeenCalledWith(context, "Runtime metrics");
+  });
 });
 
 describe("logMessage.warn", () => {
   it("logs a string message", () => {
     logMessage.warn("warn message");
     expect(mockPinoInstance.warn).toHaveBeenCalledWith("warn message");
+  });
+
+  it("logs structured context with a message", () => {
+    const context = { event: "runtime_pressure", pressure: ["event_loop_delay_p99"] };
+    logMessage.warn("Runtime pressure detected", context);
+    expect(mockPinoInstance.warn).toHaveBeenCalledWith(context, "Runtime pressure detected");
   });
 });
 

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -27,8 +27,8 @@ const pinoLogger = pino({
  */
 type AppLogger = {
   debug(message: string | Record<string, unknown>): void;
-  info(message: string): void;
-  warn(message: string): void;
+  info(message: string, context?: Record<string, unknown>): void;
+  warn(message: string, context?: Record<string, unknown>): void;
   error(message: string, cause?: unknown): void;
 };
 
@@ -63,8 +63,10 @@ export const logMessage: AppLogger = {
       }
     }
   },
-  info: (message: string) => pinoLogger.info(message),
-  warn: (message: string) => pinoLogger.warn(message),
+  info: (message: string, context?: Record<string, unknown>) =>
+    context ? pinoLogger.info(context, message) : pinoLogger.info(message),
+  warn: (message: string, context?: Record<string, unknown>) =>
+    context ? pinoLogger.warn(context, message) : pinoLogger.warn(message),
   error: (message: string, cause?: unknown) => {
     try {
       if (cause instanceof Error) {


### PR DESCRIPTION
# Summary
Add instrumentation that issues logs every 30 seconds with process metrics. This will be used to troubleshoot cases where a tasks becomes unhealthy without obvious external factors.

This additionally updates the info/warn logging to accept an optional context object.
